### PR TITLE
Linking fixes

### DIFF
--- a/Platforms/Ogre/OgrePlatform/CMakeLists.txt
+++ b/Platforms/Ogre/OgrePlatform/CMakeLists.txt
@@ -12,7 +12,7 @@ add_library(${PROJECTNAME} ${HEADER_FILES} ${SOURCE_FILES})
 
 add_dependencies(${PROJECTNAME} MyGUIEngine)
 
-target_link_libraries(${PROJECTNAME} ${OGRE_LIBRARIES})
+target_link_libraries(${PROJECTNAME} ${OGRE_LIBRARIES} MyGUIEngine)
 link_directories(${OGRE_LIB_DIR})
 
 install(FILES ${HEADER_FILES}

--- a/Platforms/OpenGL/OpenGLPlatform/CMakeLists.txt
+++ b/Platforms/OpenGL/OpenGLPlatform/CMakeLists.txt
@@ -16,7 +16,7 @@ add_library(${PROJECTNAME} ${HEADER_FILES} ${SOURCE_FILES})
 
 add_dependencies(${PROJECTNAME} MyGUIEngine)
 
-target_link_libraries(${PROJECTNAME} ${OPENGL_gl_LIBRARY} ${PNG_LIBRARIES} ${ZLIB_LIBRARIES})
+target_link_libraries(${PROJECTNAME} ${OPENGL_gl_LIBRARY} ${PNG_LIBRARIES} ${ZLIB_LIBRARIES} MyGUIEngine)
 link_directories(${OPENGL_LIB_DIR} ${PNG_LIBRARY})
 
 # installation rules


### PR DESCRIPTION
Some linking fixes, taken from Debian. These additional links now resolves every symbol in the compiled binaries.

I'll do another pull request for a build option to use system GLEW
