### PR TITLE
added travis building support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,34 @@
+language: c
+compiler:
+ - gcc
+ - clang
+env:
+ - RENDER_SYSTEM=1  # Ogre3D Platform
+ - RENDER_SYSTEM=2  # OpenGL Platform
+ - RENDER_SYSTEM=3  # Ogre3D Platform
+ - RENDER_SYSTEM=4  # OpenGL Platform
+branches:
+  only:
+    - master
+before_install:
+ - pwd
+ - git submodule update --init --recursive
+ - echo "yes" | sudo add-apt-repository "deb http://archive.ubuntu.com/ubuntu `lsb_release -sc` main universe restricted multiverse"
+ - echo "yes" | sudo apt-add-repository ppa:openmw/openmw
+ - sudo apt-get update -qq
+ - sudo apt-get install -qq cmake libogre-1.9-dev libfreetype6-dev libois-dev graphviz libgl1-mesa-dev libglew-dev doxygen
+before_script:
+ - mkdir build
+ - cd build
+ - cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DMYGUI_RENDERSYSTEM=$RENDER_SYSTEM -DMYGUI_BUILD_DEMOS=FALSE -DMYGUI_BUILD_TOOLS=FALSE ..
+script:
+ - make -j2
+
+#after_script:
+# - ./runtests
+notifications:
+  recipients:
+    - psi29a+travis.ci@gmail.com
+  email:
+    on_success: change
+    on_failure: always


### PR DESCRIPTION
I've added initial support for building on travis covering the following rendering platforms:  
  1 - Dummy  
  2 - Export (latter)  
  3 - Ogre  
  4 - OpenGL  

This also uses GCC and Clang.

I've had to run cmake with the following arguments, otherwise it fails to build on the Ogre (3) rendering platform. 
-DMYGUI_BUILD_DEMOS=FALSE -DMYGUI_BUILD_TOOLS=FALSE

I've filed an issue for it here:
https://github.com/MyGUI/mygui/issues/24

Once solved, we can remove the above arguments for better coverage.
