### PR TITLE
Fix a Bug

### DIFF
--- a/MyGUIEngine/src/MyGUI_ScrollBar.cpp
+++ b/MyGUIEngine/src/MyGUI_ScrollBar.cpp
@@ -330,6 +330,8 @@ namespace MyGUI
 
 	void ScrollBar::notifyMouseDrag(Widget* _sender, int _left, int _top, MouseButton _id)
 	{
+		if (mScrollRange < 2)
+			return;
 		if (_id == MouseButton::Left)
 			TrackMove(_left, _top);
 	}


### PR DESCRIPTION
It may crash on line 221 or 248:
int pos = start - (int)mSkinRangeStart + (getLineSize() - getTrackSize()) / (((int)mScrollRange - 1) * 2);
Integer division by zero.
Which happens in our game.
And in fuction notifyMouseWheel, this if-statement exists.
Maybe you think when mScrollRange < 2, ScrollBar is invisable, so you leave the statement out.
But In some condition,  this viewpoint is wrong.