### PR TITLE
Add ResourceManualFont::setTexture

### DIFF
--- a/MyGUIEngine/include/MyGUI_ResourceManualFont.h
+++ b/MyGUIEngine/include/MyGUI_ResourceManualFont.h
@@ -35,8 +35,11 @@ namespace MyGUI
 		virtual int getDefaultHeight();
 
 		// Manual loading methods, not needed when loading from XML
-		// Set the source texture name
+		// Set the source texture by name
 		void setSource(const std::string& value);
+		// Set the source texture directly
+		// Note: the user is responsible for deallocation of the texture.
+		void setTexture(MyGUI::ITexture* texture);
 		// Set the default height of the font
 		void setDefaultHeight(int value);
 		// Add a glyph for character 'id'

--- a/MyGUIEngine/src/MyGUI_ResourceManualFont.cpp
+++ b/MyGUIEngine/src/MyGUI_ResourceManualFont.cpp
@@ -153,6 +153,12 @@ namespace MyGUI
 		loadTexture();
 	}
 
+	void ResourceManualFont::setTexture(ITexture *texture)
+	{
+		mTexture = texture;
+		mSource.clear();
+	}
+
 	void ResourceManualFont::setDefaultHeight(int value)
 	{
 		mDefaultHeight = value;


### PR DESCRIPTION
We are switching OpenMW over to OpenSceneGraph from Ogre3D. One assumption we can now get rid of is globally managed textures. Textures can be created outside of the texture manager, and no longer need to have a name.

MyGUI seems to handle this OK, with LayerItem::setRenderItemTexture(MyGUI::ITexture*) I have an alternative to ImageBox::setImageTexture(const string&).

ResourceManualFont is missing such a method though. I am dealing with a font file that has the texture embedded within it, so making this texture global really makes no sense. I added ResourceManualFont::setTexture to set the texture by pointer.