### PR TITLE
User can specify shader to be used by Ogre renderer.

### DIFF
--- a/Platforms/Ogre/OgrePlatform/include/MyGUI_OgrePlatform.h
+++ b/Platforms/Ogre/OgrePlatform/include/MyGUI_OgrePlatform.h
@@ -40,7 +40,8 @@ namespace MyGUI
 			delete mLogManager;
 		}
 
-		void initialise(Ogre::RenderWindow* _window, Ogre::SceneManager* _scene, const std::string& _group = Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME, const std::string& _logName = MYGUI_PLATFORM_LOG_FILENAME)
+		void initialise(Ogre::RenderWindow* _window, Ogre::SceneManager* _scene, const std::string& _group = Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME, const std::string& _logName = MYGUI_PLATFORM_LOG_FILENAME,
+						const Ogre::String& _vertexProgramSrcFile = "", const Ogre::String& _fragmentProgramSrcFile = "", const Ogre::String& _shaderLanguage = "")
 		{
 			assert(!mIsInitialise);
 			mIsInitialise = true;
@@ -49,7 +50,7 @@ namespace MyGUI
 				LogManager::getInstance().createDefaultSource(_logName);
 
 			mDataManager->initialise(_group);
-			mRenderManager->initialise(_window, _scene);
+			mRenderManager->initialise(_window, _scene, _vertexProgramSrcFile, _fragmentProgramSrcFile, _shaderLanguage);
 		}
 
 		void shutdown()

--- a/Platforms/Ogre/OgrePlatform/include/MyGUI_OgreRenderManager.h
+++ b/Platforms/Ogre/OgrePlatform/include/MyGUI_OgreRenderManager.h
@@ -29,7 +29,7 @@ namespace MyGUI
 	public:
 		OgreRenderManager();
 
-		void initialise(Ogre::RenderWindow* _window, Ogre::SceneManager* _scene);
+		void initialise(Ogre::RenderWindow* _window, Ogre::SceneManager* _scene, const Ogre::String& _vertexProgramSrcFile, const Ogre::String& _fragmentProgramSrcFile, const Ogre::String& _shaderLanguage);
 		void shutdown();
 
 		static OgreRenderManager& getInstance();
@@ -67,7 +67,7 @@ namespace MyGUI
 		/** @see IRenderTarget::getInfo */
 		virtual const RenderTargetInfo& getInfo();
 
-		void setRenderSystem(Ogre::RenderSystem* _render);
+		void setRenderSystem(Ogre::RenderSystem* _render, const Ogre::String& _vertexProgramSrcFile = "", const Ogre::String& _fragmentProgramSrcFile = "", const Ogre::String& _shaderLanguage = "");
 		Ogre::RenderSystem* getRenderSystem();
 
 		void setRenderWindow(Ogre::RenderWindow* _window);
@@ -132,7 +132,7 @@ namespace MyGUI
 		bool mManualRender;
 		size_t mCountBatch;
 
-		// shaders for OpenGLES2 render
+		// shaders
 		Ogre::HighLevelGpuProgramPtr mVertexProgram;
 		Ogre::HighLevelGpuProgramPtr mFragmentProgram;
 	};

--- a/Platforms/Ogre/OgrePlatform/src/MyGUI_OgreRenderManager.cpp
+++ b/Platforms/Ogre/OgrePlatform/src/MyGUI_OgreRenderManager.cpp
@@ -37,7 +37,7 @@ namespace MyGUI
 	{
 	}
 
-	void OgreRenderManager::initialise(Ogre::RenderWindow* _window, Ogre::SceneManager* _scene)
+	void OgreRenderManager::initialise(Ogre::RenderWindow* _window, Ogre::SceneManager* _scene, const Ogre::String& _vertexProgramSrcFile, const Ogre::String& _fragmentProgramSrcFile, const Ogre::String& _shaderLanguage)
 	{
 		MYGUI_PLATFORM_ASSERT(!mIsInitialise, getClassTypeName() << " initialised twice");
 		MYGUI_PLATFORM_LOG(Info, "* Initialise: " << getClassTypeName());
@@ -64,7 +64,7 @@ namespace MyGUI
 
 		Ogre::Root* root = Ogre::Root::getSingletonPtr();
 		if (root != nullptr)
-			setRenderSystem(root->getRenderSystem());
+			setRenderSystem(root->getRenderSystem(), _vertexProgramSrcFile, _fragmentProgramSrcFile, _shaderLanguage);
 		setRenderWindow(_window);
 		setSceneManager(_scene);
 
@@ -87,7 +87,7 @@ namespace MyGUI
 		mIsInitialise = false;
 	}
 
-	void OgreRenderManager::setRenderSystem(Ogre::RenderSystem* _render)
+	void OgreRenderManager::setRenderSystem(Ogre::RenderSystem* _render, const Ogre::String& _vertexProgramSrcFile, const Ogre::String& _fragmentProgramSrcFile, const Ogre::String& _shaderLanguage)
 	{
 		// отписываемся
 		if (mRenderSystem != nullptr)
@@ -112,22 +112,22 @@ namespace MyGUI
 
 			updateRenderInfo();
 
-			if (!mRenderSystem->getFixedPipelineEnabled())
+			if (_vertexProgramSrcFile.length() > 0 && _fragmentProgramSrcFile.length() > 0)
 			{
 				mVertexProgram = Ogre::HighLevelGpuProgramManager::getSingleton().createProgram(
-					"MyGUI_VP.glsles",
+					_vertexProgramSrcFile,
 					OgreDataManager::getInstance().getGroup(),
-					"glsles",
+					_shaderLanguage,
 					Ogre::GPT_VERTEX_PROGRAM);
-				mVertexProgram->setSourceFile("MyGUI_VP.glsles");
+				mVertexProgram->setSourceFile(_vertexProgramSrcFile);
 				mVertexProgram->load();
 
 				mFragmentProgram = Ogre::HighLevelGpuProgramManager::getSingleton().createProgram(
-					"MyGUI_FP.glsles",
+					_fragmentProgramSrcFile,
 					OgreDataManager::getInstance().getGroup(),
-					"glsles",
+					_shaderLanguage,
 					Ogre::GPT_FRAGMENT_PROGRAM);
-				mFragmentProgram->setSourceFile("MyGUI_FP.glsles");
+				mFragmentProgram->setSourceFile(_fragmentProgramSrcFile);
 				mFragmentProgram->load();
 			}
 		}
@@ -341,7 +341,7 @@ namespace MyGUI
 		mRenderSystem->_setCullingMode(Ogre::CULL_NONE);
 		mRenderSystem->_setFog(Ogre::FOG_NONE);
 		mRenderSystem->_setColourBufferWriteEnabled(true, true, true, true);
-		if (mRenderSystem->getFixedPipelineEnabled())
+		if (mVertexProgram.isNull() || mFragmentProgram.isNull())
 		{
 			mRenderSystem->unbindGpuProgram(Ogre::GPT_FRAGMENT_PROGRAM);
 			mRenderSystem->unbindGpuProgram(Ogre::GPT_VERTEX_PROGRAM);


### PR DESCRIPTION
Generalized the automatically created glsles shaders created by ogre platform.
The user can specify the vertex and fragment shader and the shadiing language as parameters to MyGUI::OgrePlatform::initialise.
I use this to render MyGUI with the Ogre OpenGL3+ render system. I think other people might also find this useful.
/Pontus
