### PR TITLE
Control whether a MyGui exception will trigger a debugger call in VisualC++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,6 +162,7 @@ endif()
 
 if (MSVC)
 	option(MYGUI_USE_PROJECT_FOLDERS "Use Visual Studio solution folders for projects." FALSE)
+	option(MYGUI_BREAKPOINT_ON_EXCEPT "Call the debugger on a MyGUI Exception" TRUE)
 endif ()
 
 # Used to not annoy users with high level warnings (should be TRUE for developers)
@@ -182,6 +183,11 @@ endif ()
 if (MYGUI_DONT_USE_OBSOLETE)
 	add_definitions(-DMYGUI_DONT_USE_OBSOLETE)
 endif ()
+
+if (MYGUI_BREAKPOINT_ON_EXCEPT)
+	add_definitions(-DMYGUI_BREAKPOINT_ON_EXCEPT)
+endif ()
+
 # End of Global defines
 
 # Set compiler specific build flags

--- a/MyGUIEngine/include/MyGUI_Diagnostic.h
+++ b/MyGUIEngine/include/MyGUI_Diagnostic.h
@@ -24,7 +24,7 @@
 #define MYGUI_BASE_EXCEPT(desc, src)	 throw MyGUI::Exception(desc, src, __FILE__, __LINE__);
 
 // MSVC specific: sets the breakpoint
-#if MYGUI_COMPILER == MYGUI_COMPILER_MSVC
+#if (MYGUI_COMPILER == MYGUI_COMPILER_MSVC) && defined(MYGUI_BREAKPOINT_ON_EXCEPT)
 #	define MYGUI_DBG_BREAK _CrtDbgBreak();
 #else
 #	define MYGUI_DBG_BREAK


### PR DESCRIPTION
When compiled in Visual C++, the MYGUI_EXCEPT macro calls the debugger before throwing the exception. This behaviour is quite annoying when writing unit tests that trigger exceptions on purpose, and in my application I want to catch those exceptions myself.
I've added an option in CMake to disable that debugger call. The breakpoint is still put by default, and the option can just be set to false to remove it.