### PR TITLE
Fix lost key focus event not being triggered sometimes

### DIFF
--- a/MyGUIEngine/src/MyGUI_InputManager.cpp
+++ b/MyGUIEngine/src/MyGUI_InputManager.cpp
@@ -485,7 +485,7 @@ namespace MyGUI
 
 		if (_widget == mWidgetKeyFocus)
 		{
-			mWidgetKeyFocus = nullptr;
+			resetKeyFocusWidget();
 		}
 
 		// ручками сбрасываем, чтобы не менять фокусы


### PR DESCRIPTION
Steps to reproduce:
1. Focus edit box
2. Disable input on editboxes using `setEnabled(false)`
3. Click in an empty region
==> lost key event is not triggered