### PR TITLE
Supports SDL2 in samples.

### DIFF
--- a/CMake/Dependencies.cmake
+++ b/CMake/Dependencies.cmake
@@ -97,6 +97,8 @@ if (MYGUI_SAMPLES_INPUT EQUAL 1)
 elseif (MYGUI_SAMPLES_INPUT EQUAL 3)
 	find_package(OIS)
 	macro_log_feature(OIS_FOUND "OIS" "Input library needed for the samples" "http://sourceforge.net/projects/wgois" FALSE "" "")
+elseif (MYGUI_SAMPLES_INPUT EQUAL 4)
+	find_package(SDL2)
 endif()
 
 #######################################################################

--- a/Common/Base/Ogre2/BaseManager.h
+++ b/Common/Base/Ogre2/BaseManager.h
@@ -16,6 +16,13 @@
 #include "PointerManager.h"
 #include "MyGUI_LastHeader.h"
 
+#ifdef MYGUI_SAMPLES_INPUT_SDL2
+#include "SdlEmulationLayer.h"
+#endif
+#if MYGUI_USE_SDL2
+#include <SDL.h>
+#endif
+
 namespace MyGUI
 {
 	class Ogre2Platform;
@@ -23,7 +30,9 @@ namespace MyGUI
 
 namespace base
 {
-
+#ifdef MYGUI_USE_SDL2
+	class SdlInputHandler;
+#endif
 	class BaseManager :
 		public input::InputManager,
 		public input::PointerManager,
@@ -101,6 +110,11 @@ namespace base
 		std::string mResourceXMLName;
 		std::string mResourceFileName;
 		std::string mRootMedia;
+#ifdef MYGUI_USE_SDL2
+		void handleWindowEvent(const SDL_Event& evt);
+		SDL_Window* mSdlWindow;
+        SdlInputHandler* mInputHandler;
+#endif
 	};
 
 } // namespace base

--- a/Common/CMakeLists.txt
+++ b/Common/CMakeLists.txt
@@ -16,18 +16,28 @@ function(mygui_add_input_source PLATFORM)
 	include_directories(Input/${PLATFORM})
 	if("${PLATFORM}" STREQUAL "SDL")
 		set (HEADER_FILES ${HEADER_FILES}
-			Input/${PLATFORM}/SDL_InputManager.h
-			Input/${PLATFORM}/SDL_PointerManager.h
+			Input/${PLATFORM}/InputManager.h
+			Input/${PLATFORM}/PointerManager.h
+			Input/${PLATFORM}/SdlInputHandler.h
+			Input/${PLATFORM}/SdlEmulationLayer.h
+			Input/${PLATFORM}/ResourceSDLPointer.h
 			PARENT_SCOPE)
 		set (SOURCE_FILES ${SOURCE_FILES}
-			Input/${PLATFORM}/SDL_InputManager.cpp
-			Input/${PLATFORM}/SDL_PointerManager.cpp
+			Input/${PLATFORM}/InputManager.cpp
+			Input/${PLATFORM}/PointerManager.cpp
+			Input/${PLATFORM}/SdlInputHandler.cpp
+			Input/${PLATFORM}/ResourceSDLPointer.cpp
 			PARENT_SCOPE)
 		SOURCE_GROUP("Base" FILES
-			Input/${PLATFORM}/SDL_InputManager.h
-			Input/${PLATFORM}/SDL_InputManager.cpp
-			Input/${PLATFORM}/SDL_PointerManager.h
-			Input/${PLATFORM}/SDL_PointerManager.cpp
+			Input/${PLATFORM}/InputManager.h
+			Input/${PLATFORM}/InputManager.cpp
+			Input/${PLATFORM}/PointerManager.h
+			Input/${PLATFORM}/PointerManager.cpp
+			Input/${PLATFORM}/SdlInputHandler.h
+			Input/${PLATFORM}/SdlInputHandler.cpp
+			Input/${PLATFORM}/SdlEmulationLayer.h
+			Input/${PLATFORM}/ResourceSDLPointer.h
+			Input/${PLATFORM}/ResourceSDLPointer.cpp
 		)
 	else("${PLATFORM}" STREQUAL "SDL")
 		set (HEADER_FILES ${HEADER_FILES}

--- a/Common/Input/SDL/InputManager.cpp
+++ b/Common/Input/SDL/InputManager.cpp
@@ -5,11 +5,10 @@
 */
 
 #include "Precompiled.h"
-#include "SDL_InputManager.h"
+#include "InputManager.h"
 
 namespace input
 {
-
 	InputManager::InputManager() :
 		mMouseX(0),
 		mMouseY(0),

--- a/Common/Input/SDL/InputManager.h
+++ b/Common/Input/SDL/InputManager.h
@@ -7,6 +7,10 @@
 #ifndef INPUT_MANAGER_H_
 #define INPUT_MANAGER_H_
 
+#ifdef MYGUI_SAMPLES_INPUT_SDL2
+#include "SdlEmulationLayer.h"
+#endif
+
 #include <MyGUI.h>
 #include <SDL.h>
 
@@ -36,7 +40,7 @@ namespace input
 		void setMousePosition(int _x, int _y);
 		void updateCursorPosition();
 
-	protected:
+//	protected:
 		void frameEvent(float _time);
 		void computeMouseMove();
 
@@ -54,6 +58,15 @@ namespace input
 
 		void buildVKeyMap();
 		void buildMouseButtonMap();
+		MyGUI::MouseButton GetMouseButton(int id)
+		{
+			std::map<int, MyGUI::MouseButton>::iterator it = mSDLMouseMap.find(id);
+			if (it == mSDLMouseMap.end()) return MyGUI::MouseButton::None;
+			else return it->second;
+		}
+
+		int getMouseZ(){ return mMouseZ; }
+
 	private:
 		int mMouseX;
 		int mMouseY;

--- a/Common/Input/SDL/PointerManager.cpp
+++ b/Common/Input/SDL/PointerManager.cpp
@@ -5,10 +5,10 @@
 */
 
 #include "Precompiled.h"
-#include "SDL_PointerManager.h"
+#include "PointerManager.h"
 #include <MyGUI.h>
 
-#include "ResourceSDLPointer.cpp"
+#include "ResourceSDLPointer.h"
 
 namespace input
 {

--- a/Common/Input/SDL/PointerManager.h
+++ b/Common/Input/SDL/PointerManager.h
@@ -7,6 +7,10 @@
 #ifndef POINTER_MANAGER_H_
 #define POINTER_MANAGER_H_
 
+#ifdef MYGUI_SAMPLES_INPUT_SDL2
+#include "SdlEmulationLayer.h"
+#endif
+
 #include <string>
 #include <SDL.h>
 

--- a/Common/Input/SDL/ResourceSDLPointer.cpp
+++ b/Common/Input/SDL/ResourceSDLPointer.cpp
@@ -5,7 +5,10 @@
 	@module
 */
 
+#include "Precompiled.h"
 #include "ResourceSDLPointer.h"
+
+#if MYGUI_USE_SDL2
 
 namespace input
 {
@@ -62,3 +65,5 @@ namespace input
 	}
 
 }
+
+#endif

--- a/Common/Input/SDL/ResourceSDLPointer.h
+++ b/Common/Input/SDL/ResourceSDLPointer.h
@@ -8,6 +8,10 @@
 #ifndef RESOURCE_W32_POINTER_H_
 #define RESOURCE_W32_POINTER_H_
 
+#ifdef MYGUI_SAMPLES_INPUT_SDL2
+#include "SdlEmulationLayer.h"
+#endif
+
 #include "MyGUI_Prerequest.h"
 #include "MyGUI_IResource.h"
 

--- a/Common/Input/SDL/SdlEmulationLayer.h
+++ b/Common/Input/SDL/SdlEmulationLayer.h
@@ -1,0 +1,745 @@
+
+#ifndef _Base_SdlEmulationLayer_H_
+#define _Base_SdlEmulationLayer_H_
+
+#if MYGUI_PLATFORM == MYGUI_PLATFORM_APPLE_IOS
+    #define MYGUI_USE_SDL2 0
+
+    typedef Ogre::int32 SDL_Keycode;
+
+    /**
+     *  \brief The SDL keyboard scancode representation.
+     *
+     *  Values of this type are used to represent keyboard keys, among other places
+     *  in the \link SDL_Keysym::scancode key.keysym.scancode \endlink field of the
+     *  SDL_Event structure.
+     *
+     *  The values in this enumeration are based on the USB usage page standard:
+     *  http://www.usb.org/developers/devclass_docs/Hut1_12v2.pdf
+     */
+    typedef enum
+    {
+        SDL_SCANCODE_UNKNOWN = 0,
+
+        /**
+         *  \name Usage page 0x07
+         *
+         *  These values are from usage page 0x07 (USB keyboard page).
+         */
+        /* @{ */
+
+        SDL_SCANCODE_A = 4,
+        SDL_SCANCODE_B = 5,
+        SDL_SCANCODE_C = 6,
+        SDL_SCANCODE_D = 7,
+        SDL_SCANCODE_E = 8,
+        SDL_SCANCODE_F = 9,
+        SDL_SCANCODE_G = 10,
+        SDL_SCANCODE_H = 11,
+        SDL_SCANCODE_I = 12,
+        SDL_SCANCODE_J = 13,
+        SDL_SCANCODE_K = 14,
+        SDL_SCANCODE_L = 15,
+        SDL_SCANCODE_M = 16,
+        SDL_SCANCODE_N = 17,
+        SDL_SCANCODE_O = 18,
+        SDL_SCANCODE_P = 19,
+        SDL_SCANCODE_Q = 20,
+        SDL_SCANCODE_R = 21,
+        SDL_SCANCODE_S = 22,
+        SDL_SCANCODE_T = 23,
+        SDL_SCANCODE_U = 24,
+        SDL_SCANCODE_V = 25,
+        SDL_SCANCODE_W = 26,
+        SDL_SCANCODE_X = 27,
+        SDL_SCANCODE_Y = 28,
+        SDL_SCANCODE_Z = 29,
+
+        SDL_SCANCODE_1 = 30,
+        SDL_SCANCODE_2 = 31,
+        SDL_SCANCODE_3 = 32,
+        SDL_SCANCODE_4 = 33,
+        SDL_SCANCODE_5 = 34,
+        SDL_SCANCODE_6 = 35,
+        SDL_SCANCODE_7 = 36,
+        SDL_SCANCODE_8 = 37,
+        SDL_SCANCODE_9 = 38,
+        SDL_SCANCODE_0 = 39,
+
+        SDL_SCANCODE_RETURN = 40,
+        SDL_SCANCODE_ESCAPE = 41,
+        SDL_SCANCODE_BACKSPACE = 42,
+        SDL_SCANCODE_TAB = 43,
+        SDL_SCANCODE_SPACE = 44,
+
+        SDL_SCANCODE_MINUS = 45,
+        SDL_SCANCODE_EQUALS = 46,
+        SDL_SCANCODE_LEFTBRACKET = 47,
+        SDL_SCANCODE_RIGHTBRACKET = 48,
+        SDL_SCANCODE_BACKSLASH = 49, /**< Located at the lower left of the return
+                                      *   key on ISO keyboards and at the right end
+                                      *   of the QWERTY row on ANSI keyboards.
+                                      *   Produces REVERSE SOLIDUS (backslash) and
+                                      *   VERTICAL LINE in a US layout, REVERSE
+                                      *   SOLIDUS and VERTICAL LINE in a UK Mac
+                                      *   layout, NUMBER SIGN and TILDE in a UK
+                                      *   Windows layout, DOLLAR SIGN and POUND SIGN
+                                      *   in a Swiss German layout, NUMBER SIGN and
+                                      *   APOSTROPHE in a German layout, GRAVE
+                                      *   ACCENT and POUND SIGN in a French Mac
+                                      *   layout, and ASTERISK and MICRO SIGN in a
+                                      *   French Windows layout.
+                                      */
+        SDL_SCANCODE_NONUSHASH = 50, /**< ISO USB keyboards actually use this code
+                                      *   instead of 49 for the same key, but all
+                                      *   OSes I've seen treat the two codes
+                                      *   identically. So, as an implementor, unless
+                                      *   your keyboard generates both of those
+                                      *   codes and your OS treats them differently,
+                                      *   you should generate SDL_SCANCODE_BACKSLASH
+                                      *   instead of this code. As a user, you
+                                      *   should not rely on this code because SDL
+                                      *   will never generate it with most (all?)
+                                      *   keyboards.
+                                      */
+        SDL_SCANCODE_SEMICOLON = 51,
+        SDL_SCANCODE_APOSTROPHE = 52,
+        SDL_SCANCODE_GRAVE = 53, /**< Located in the top left corner (on both ANSI
+                                  *   and ISO keyboards). Produces GRAVE ACCENT and
+                                  *   TILDE in a US Windows layout and in US and UK
+                                  *   Mac layouts on ANSI keyboards, GRAVE ACCENT
+                                  *   and NOT SIGN in a UK Windows layout, SECTION
+                                  *   SIGN and PLUS-MINUS SIGN in US and UK Mac
+                                  *   layouts on ISO keyboards, SECTION SIGN and
+                                  *   DEGREE SIGN in a Swiss German layout (Mac:
+                                  *   only on ISO keyboards), CIRCUMFLEX ACCENT and
+                                  *   DEGREE SIGN in a German layout (Mac: only on
+                                  *   ISO keyboards), SUPERSCRIPT TWO and TILDE in a
+                                  *   French Windows layout, COMMERCIAL AT and
+                                  *   NUMBER SIGN in a French Mac layout on ISO
+                                  *   keyboards, and LESS-THAN SIGN and GREATER-THAN
+                                  *   SIGN in a Swiss German, German, or French Mac
+                                  *   layout on ANSI keyboards.
+                                  */
+        SDL_SCANCODE_COMMA = 54,
+        SDL_SCANCODE_PERIOD = 55,
+        SDL_SCANCODE_SLASH = 56,
+
+        SDL_SCANCODE_CAPSLOCK = 57,
+
+        SDL_SCANCODE_F1 = 58,
+        SDL_SCANCODE_F2 = 59,
+        SDL_SCANCODE_F3 = 60,
+        SDL_SCANCODE_F4 = 61,
+        SDL_SCANCODE_F5 = 62,
+        SDL_SCANCODE_F6 = 63,
+        SDL_SCANCODE_F7 = 64,
+        SDL_SCANCODE_F8 = 65,
+        SDL_SCANCODE_F9 = 66,
+        SDL_SCANCODE_F10 = 67,
+        SDL_SCANCODE_F11 = 68,
+        SDL_SCANCODE_F12 = 69,
+
+        SDL_SCANCODE_PRINTSCREEN = 70,
+        SDL_SCANCODE_SCROLLLOCK = 71,
+        SDL_SCANCODE_PAUSE = 72,
+        SDL_SCANCODE_INSERT = 73, /**< insert on PC, help on some Mac keyboards (but
+                                       does send code 73, not 117) */
+        SDL_SCANCODE_HOME = 74,
+        SDL_SCANCODE_PAGEUP = 75,
+        SDL_SCANCODE_DELETE = 76,
+        SDL_SCANCODE_END = 77,
+        SDL_SCANCODE_PAGEDOWN = 78,
+        SDL_SCANCODE_RIGHT = 79,
+        SDL_SCANCODE_LEFT = 80,
+        SDL_SCANCODE_DOWN = 81,
+        SDL_SCANCODE_UP = 82,
+
+        SDL_SCANCODE_NUMLOCKCLEAR = 83, /**< num lock on PC, clear on Mac keyboards
+                                         */
+        SDL_SCANCODE_KP_DIVIDE = 84,
+        SDL_SCANCODE_KP_MULTIPLY = 85,
+        SDL_SCANCODE_KP_MINUS = 86,
+        SDL_SCANCODE_KP_PLUS = 87,
+        SDL_SCANCODE_KP_ENTER = 88,
+        SDL_SCANCODE_KP_1 = 89,
+        SDL_SCANCODE_KP_2 = 90,
+        SDL_SCANCODE_KP_3 = 91,
+        SDL_SCANCODE_KP_4 = 92,
+        SDL_SCANCODE_KP_5 = 93,
+        SDL_SCANCODE_KP_6 = 94,
+        SDL_SCANCODE_KP_7 = 95,
+        SDL_SCANCODE_KP_8 = 96,
+        SDL_SCANCODE_KP_9 = 97,
+        SDL_SCANCODE_KP_0 = 98,
+        SDL_SCANCODE_KP_PERIOD = 99,
+
+        SDL_SCANCODE_NONUSBACKSLASH = 100, /**< This is the additional key that ISO
+                                            *   keyboards have over ANSI ones,
+                                            *   located between left shift and Y.
+                                            *   Produces GRAVE ACCENT and TILDE in a
+                                            *   US or UK Mac layout, REVERSE SOLIDUS
+                                            *   (backslash) and VERTICAL LINE in a
+                                            *   US or UK Windows layout, and
+                                            *   LESS-THAN SIGN and GREATER-THAN SIGN
+                                            *   in a Swiss German, German, or French
+                                            *   layout. */
+        SDL_SCANCODE_APPLICATION = 101, /**< windows contextual menu, compose */
+        SDL_SCANCODE_POWER = 102, /**< The USB document says this is a status flag,
+                                   *   not a physical key - but some Mac keyboards
+                                   *   do have a power key. */
+        SDL_SCANCODE_KP_EQUALS = 103,
+        SDL_SCANCODE_F13 = 104,
+        SDL_SCANCODE_F14 = 105,
+        SDL_SCANCODE_F15 = 106,
+        SDL_SCANCODE_F16 = 107,
+        SDL_SCANCODE_F17 = 108,
+        SDL_SCANCODE_F18 = 109,
+        SDL_SCANCODE_F19 = 110,
+        SDL_SCANCODE_F20 = 111,
+        SDL_SCANCODE_F21 = 112,
+        SDL_SCANCODE_F22 = 113,
+        SDL_SCANCODE_F23 = 114,
+        SDL_SCANCODE_F24 = 115,
+        SDL_SCANCODE_EXECUTE = 116,
+        SDL_SCANCODE_HELP = 117,
+        SDL_SCANCODE_MENU = 118,
+        SDL_SCANCODE_SELECT = 119,
+        SDL_SCANCODE_STOP = 120,
+        SDL_SCANCODE_AGAIN = 121,   /**< redo */
+        SDL_SCANCODE_UNDO = 122,
+        SDL_SCANCODE_CUT = 123,
+        SDL_SCANCODE_COPY = 124,
+        SDL_SCANCODE_PASTE = 125,
+        SDL_SCANCODE_FIND = 126,
+        SDL_SCANCODE_MUTE = 127,
+        SDL_SCANCODE_VOLUMEUP = 128,
+        SDL_SCANCODE_VOLUMEDOWN = 129,
+    /* not sure whether there's a reason to enable these */
+    /*     SDL_SCANCODE_LOCKINGCAPSLOCK = 130,  */
+    /*     SDL_SCANCODE_LOCKINGNUMLOCK = 131, */
+    /*     SDL_SCANCODE_LOCKINGSCROLLLOCK = 132, */
+        SDL_SCANCODE_KP_COMMA = 133,
+        SDL_SCANCODE_KP_EQUALSAS400 = 134,
+
+        SDL_SCANCODE_INTERNATIONAL1 = 135, /**< used on Asian keyboards, see
+                                                footnotes in USB doc */
+        SDL_SCANCODE_INTERNATIONAL2 = 136,
+        SDL_SCANCODE_INTERNATIONAL3 = 137, /**< Yen */
+        SDL_SCANCODE_INTERNATIONAL4 = 138,
+        SDL_SCANCODE_INTERNATIONAL5 = 139,
+        SDL_SCANCODE_INTERNATIONAL6 = 140,
+        SDL_SCANCODE_INTERNATIONAL7 = 141,
+        SDL_SCANCODE_INTERNATIONAL8 = 142,
+        SDL_SCANCODE_INTERNATIONAL9 = 143,
+        SDL_SCANCODE_LANG1 = 144, /**< Hangul/English toggle */
+        SDL_SCANCODE_LANG2 = 145, /**< Hanja conversion */
+        SDL_SCANCODE_LANG3 = 146, /**< Katakana */
+        SDL_SCANCODE_LANG4 = 147, /**< Hiragana */
+        SDL_SCANCODE_LANG5 = 148, /**< Zenkaku/Hankaku */
+        SDL_SCANCODE_LANG6 = 149, /**< reserved */
+        SDL_SCANCODE_LANG7 = 150, /**< reserved */
+        SDL_SCANCODE_LANG8 = 151, /**< reserved */
+        SDL_SCANCODE_LANG9 = 152, /**< reserved */
+
+        SDL_SCANCODE_ALTERASE = 153, /**< Erase-Eaze */
+        SDL_SCANCODE_SYSREQ = 154,
+        SDL_SCANCODE_CANCEL = 155,
+        SDL_SCANCODE_CLEAR = 156,
+        SDL_SCANCODE_PRIOR = 157,
+        SDL_SCANCODE_RETURN2 = 158,
+        SDL_SCANCODE_SEPARATOR = 159,
+        SDL_SCANCODE_OUT = 160,
+        SDL_SCANCODE_OPER = 161,
+        SDL_SCANCODE_CLEARAGAIN = 162,
+        SDL_SCANCODE_CRSEL = 163,
+        SDL_SCANCODE_EXSEL = 164,
+
+        SDL_SCANCODE_KP_00 = 176,
+        SDL_SCANCODE_KP_000 = 177,
+        SDL_SCANCODE_THOUSANDSSEPARATOR = 178,
+        SDL_SCANCODE_DECIMALSEPARATOR = 179,
+        SDL_SCANCODE_CURRENCYUNIT = 180,
+        SDL_SCANCODE_CURRENCYSUBUNIT = 181,
+        SDL_SCANCODE_KP_LEFTPAREN = 182,
+        SDL_SCANCODE_KP_RIGHTPAREN = 183,
+        SDL_SCANCODE_KP_LEFTBRACE = 184,
+        SDL_SCANCODE_KP_RIGHTBRACE = 185,
+        SDL_SCANCODE_KP_TAB = 186,
+        SDL_SCANCODE_KP_BACKSPACE = 187,
+        SDL_SCANCODE_KP_A = 188,
+        SDL_SCANCODE_KP_B = 189,
+        SDL_SCANCODE_KP_C = 190,
+        SDL_SCANCODE_KP_D = 191,
+        SDL_SCANCODE_KP_E = 192,
+        SDL_SCANCODE_KP_F = 193,
+        SDL_SCANCODE_KP_XOR = 194,
+        SDL_SCANCODE_KP_POWER = 195,
+        SDL_SCANCODE_KP_PERCENT = 196,
+        SDL_SCANCODE_KP_LESS = 197,
+        SDL_SCANCODE_KP_GREATER = 198,
+        SDL_SCANCODE_KP_AMPERSAND = 199,
+        SDL_SCANCODE_KP_DBLAMPERSAND = 200,
+        SDL_SCANCODE_KP_VERTICALBAR = 201,
+        SDL_SCANCODE_KP_DBLVERTICALBAR = 202,
+        SDL_SCANCODE_KP_COLON = 203,
+        SDL_SCANCODE_KP_HASH = 204,
+        SDL_SCANCODE_KP_SPACE = 205,
+        SDL_SCANCODE_KP_AT = 206,
+        SDL_SCANCODE_KP_EXCLAM = 207,
+        SDL_SCANCODE_KP_MEMSTORE = 208,
+        SDL_SCANCODE_KP_MEMRECALL = 209,
+        SDL_SCANCODE_KP_MEMCLEAR = 210,
+        SDL_SCANCODE_KP_MEMADD = 211,
+        SDL_SCANCODE_KP_MEMSUBTRACT = 212,
+        SDL_SCANCODE_KP_MEMMULTIPLY = 213,
+        SDL_SCANCODE_KP_MEMDIVIDE = 214,
+        SDL_SCANCODE_KP_PLUSMINUS = 215,
+        SDL_SCANCODE_KP_CLEAR = 216,
+        SDL_SCANCODE_KP_CLEARENTRY = 217,
+        SDL_SCANCODE_KP_BINARY = 218,
+        SDL_SCANCODE_KP_OCTAL = 219,
+        SDL_SCANCODE_KP_DECIMAL = 220,
+        SDL_SCANCODE_KP_HEXADECIMAL = 221,
+
+        SDL_SCANCODE_LCTRL = 224,
+        SDL_SCANCODE_LSHIFT = 225,
+        SDL_SCANCODE_LALT = 226, /**< alt, option */
+        SDL_SCANCODE_LGUI = 227, /**< windows, command (apple), meta */
+        SDL_SCANCODE_RCTRL = 228,
+        SDL_SCANCODE_RSHIFT = 229,
+        SDL_SCANCODE_RALT = 230, /**< alt gr, option */
+        SDL_SCANCODE_RGUI = 231, /**< windows, command (apple), meta */
+
+        SDL_SCANCODE_MODE = 257,    /**< I'm not sure if this is really not covered
+                                     *   by any of the above, but since there's a
+                                     *   special KMOD_MODE for it I'm adding it here
+                                     */
+
+        /* @} *//* Usage page 0x07 */
+
+        /**
+         *  \name Usage page 0x0C
+         *
+         *  These values are mapped from usage page 0x0C (USB consumer page).
+         */
+        /* @{ */
+
+        SDL_SCANCODE_AUDIONEXT = 258,
+        SDL_SCANCODE_AUDIOPREV = 259,
+        SDL_SCANCODE_AUDIOSTOP = 260,
+        SDL_SCANCODE_AUDIOPLAY = 261,
+        SDL_SCANCODE_AUDIOMUTE = 262,
+        SDL_SCANCODE_MEDIASELECT = 263,
+        SDL_SCANCODE_WWW = 264,
+        SDL_SCANCODE_MAIL = 265,
+        SDL_SCANCODE_CALCULATOR = 266,
+        SDL_SCANCODE_COMPUTER = 267,
+        SDL_SCANCODE_AC_SEARCH = 268,
+        SDL_SCANCODE_AC_HOME = 269,
+        SDL_SCANCODE_AC_BACK = 270,
+        SDL_SCANCODE_AC_FORWARD = 271,
+        SDL_SCANCODE_AC_STOP = 272,
+        SDL_SCANCODE_AC_REFRESH = 273,
+        SDL_SCANCODE_AC_BOOKMARKS = 274,
+
+        /* @} *//* Usage page 0x0C */
+
+        /**
+         *  \name Walther keys
+         *
+         *  These are values that Christian Walther added (for mac keyboard?).
+         */
+        /* @{ */
+
+        SDL_SCANCODE_BRIGHTNESSDOWN = 275,
+        SDL_SCANCODE_BRIGHTNESSUP = 276,
+        SDL_SCANCODE_DISPLAYSWITCH = 277, /**< display mirroring/dual display
+                                               switch, video mode switch */
+        SDL_SCANCODE_KBDILLUMTOGGLE = 278,
+        SDL_SCANCODE_KBDILLUMDOWN = 279,
+        SDL_SCANCODE_KBDILLUMUP = 280,
+        SDL_SCANCODE_EJECT = 281,
+        SDL_SCANCODE_SLEEP = 282,
+
+        SDL_SCANCODE_APP1 = 283,
+        SDL_SCANCODE_APP2 = 284,
+
+        /* @} *//* Walther keys */
+
+        /* Add any other keys here. */
+
+        SDL_NUM_SCANCODES = 512 /**< not a key, just marks the number of scancodes
+                                     for array bounds */
+    } SDL_Scancode;
+
+    #define SDLK_SCANCODE_MASK (1<<30)
+    #define SDL_SCANCODE_TO_KEYCODE(X)  (X | SDLK_SCANCODE_MASK)
+
+    enum
+    {
+        SDLK_UNKNOWN = 0,
+
+        SDLK_RETURN = '\r',
+        SDLK_ESCAPE = '\033',
+        SDLK_BACKSPACE = '\b',
+        SDLK_TAB = '\t',
+        SDLK_SPACE = ' ',
+        SDLK_EXCLAIM = '!',
+        SDLK_QUOTEDBL = '"',
+        SDLK_HASH = '#',
+        SDLK_PERCENT = '%',
+        SDLK_DOLLAR = '$',
+        SDLK_AMPERSAND = '&',
+        SDLK_QUOTE = '\'',
+        SDLK_LEFTPAREN = '(',
+        SDLK_RIGHTPAREN = ')',
+        SDLK_ASTERISK = '*',
+        SDLK_PLUS = '+',
+        SDLK_COMMA = ',',
+        SDLK_MINUS = '-',
+        SDLK_PERIOD = '.',
+        SDLK_SLASH = '/',
+        SDLK_0 = '0',
+        SDLK_1 = '1',
+        SDLK_2 = '2',
+        SDLK_3 = '3',
+        SDLK_4 = '4',
+        SDLK_5 = '5',
+        SDLK_6 = '6',
+        SDLK_7 = '7',
+        SDLK_8 = '8',
+        SDLK_9 = '9',
+        SDLK_COLON = ':',
+        SDLK_SEMICOLON = ';',
+        SDLK_LESS = '<',
+        SDLK_EQUALS = '=',
+        SDLK_GREATER = '>',
+        SDLK_QUESTION = '?',
+        SDLK_AT = '@',
+        /*
+           Skip uppercase letters
+         */
+        SDLK_LEFTBRACKET = '[',
+        SDLK_BACKSLASH = '\\',
+        SDLK_RIGHTBRACKET = ']',
+        SDLK_CARET = '^',
+        SDLK_UNDERSCORE = '_',
+        SDLK_BACKQUOTE = '`',
+        SDLK_a = 'a',
+        SDLK_b = 'b',
+        SDLK_c = 'c',
+        SDLK_d = 'd',
+        SDLK_e = 'e',
+        SDLK_f = 'f',
+        SDLK_g = 'g',
+        SDLK_h = 'h',
+        SDLK_i = 'i',
+        SDLK_j = 'j',
+        SDLK_k = 'k',
+        SDLK_l = 'l',
+        SDLK_m = 'm',
+        SDLK_n = 'n',
+        SDLK_o = 'o',
+        SDLK_p = 'p',
+        SDLK_q = 'q',
+        SDLK_r = 'r',
+        SDLK_s = 's',
+        SDLK_t = 't',
+        SDLK_u = 'u',
+        SDLK_v = 'v',
+        SDLK_w = 'w',
+        SDLK_x = 'x',
+        SDLK_y = 'y',
+        SDLK_z = 'z',
+
+        SDLK_CAPSLOCK = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_CAPSLOCK),
+
+        SDLK_F1 = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_F1),
+        SDLK_F2 = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_F2),
+        SDLK_F3 = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_F3),
+        SDLK_F4 = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_F4),
+        SDLK_F5 = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_F5),
+        SDLK_F6 = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_F6),
+        SDLK_F7 = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_F7),
+        SDLK_F8 = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_F8),
+        SDLK_F9 = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_F9),
+        SDLK_F10 = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_F10),
+        SDLK_F11 = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_F11),
+        SDLK_F12 = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_F12),
+
+        SDLK_PRINTSCREEN = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_PRINTSCREEN),
+        SDLK_SCROLLLOCK = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_SCROLLLOCK),
+        SDLK_PAUSE = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_PAUSE),
+        SDLK_INSERT = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_INSERT),
+        SDLK_HOME = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_HOME),
+        SDLK_PAGEUP = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_PAGEUP),
+        SDLK_DELETE = '\177',
+        SDLK_END = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_END),
+        SDLK_PAGEDOWN = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_PAGEDOWN),
+        SDLK_RIGHT = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_RIGHT),
+        SDLK_LEFT = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_LEFT),
+        SDLK_DOWN = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_DOWN),
+        SDLK_UP = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_UP),
+
+        SDLK_NUMLOCKCLEAR = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_NUMLOCKCLEAR),
+        SDLK_KP_DIVIDE = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_KP_DIVIDE),
+        SDLK_KP_MULTIPLY = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_KP_MULTIPLY),
+        SDLK_KP_MINUS = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_KP_MINUS),
+        SDLK_KP_PLUS = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_KP_PLUS),
+        SDLK_KP_ENTER = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_KP_ENTER),
+        SDLK_KP_1 = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_KP_1),
+        SDLK_KP_2 = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_KP_2),
+        SDLK_KP_3 = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_KP_3),
+        SDLK_KP_4 = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_KP_4),
+        SDLK_KP_5 = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_KP_5),
+        SDLK_KP_6 = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_KP_6),
+        SDLK_KP_7 = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_KP_7),
+        SDLK_KP_8 = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_KP_8),
+        SDLK_KP_9 = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_KP_9),
+        SDLK_KP_0 = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_KP_0),
+        SDLK_KP_PERIOD = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_KP_PERIOD),
+
+        SDLK_APPLICATION = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_APPLICATION),
+        SDLK_POWER = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_POWER),
+        SDLK_KP_EQUALS = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_KP_EQUALS),
+        SDLK_F13 = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_F13),
+        SDLK_F14 = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_F14),
+        SDLK_F15 = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_F15),
+        SDLK_F16 = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_F16),
+        SDLK_F17 = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_F17),
+        SDLK_F18 = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_F18),
+        SDLK_F19 = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_F19),
+        SDLK_F20 = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_F20),
+        SDLK_F21 = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_F21),
+        SDLK_F22 = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_F22),
+        SDLK_F23 = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_F23),
+        SDLK_F24 = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_F24),
+        SDLK_EXECUTE = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_EXECUTE),
+        SDLK_HELP = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_HELP),
+        SDLK_MENU = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_MENU),
+        SDLK_SELECT = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_SELECT),
+        SDLK_STOP = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_STOP),
+        SDLK_AGAIN = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_AGAIN),
+        SDLK_UNDO = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_UNDO),
+        SDLK_CUT = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_CUT),
+        SDLK_COPY = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_COPY),
+        SDLK_PASTE = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_PASTE),
+        SDLK_FIND = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_FIND),
+        SDLK_MUTE = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_MUTE),
+        SDLK_VOLUMEUP = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_VOLUMEUP),
+        SDLK_VOLUMEDOWN = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_VOLUMEDOWN),
+        SDLK_KP_COMMA = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_KP_COMMA),
+        SDLK_KP_EQUALSAS400 =
+            SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_KP_EQUALSAS400),
+
+        SDLK_ALTERASE = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_ALTERASE),
+        SDLK_SYSREQ = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_SYSREQ),
+        SDLK_CANCEL = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_CANCEL),
+        SDLK_CLEAR = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_CLEAR),
+        SDLK_PRIOR = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_PRIOR),
+        SDLK_RETURN2 = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_RETURN2),
+        SDLK_SEPARATOR = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_SEPARATOR),
+        SDLK_OUT = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_OUT),
+        SDLK_OPER = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_OPER),
+        SDLK_CLEARAGAIN = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_CLEARAGAIN),
+        SDLK_CRSEL = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_CRSEL),
+        SDLK_EXSEL = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_EXSEL),
+
+        SDLK_KP_00 = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_KP_00),
+        SDLK_KP_000 = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_KP_000),
+        SDLK_THOUSANDSSEPARATOR =
+            SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_THOUSANDSSEPARATOR),
+        SDLK_DECIMALSEPARATOR =
+            SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_DECIMALSEPARATOR),
+        SDLK_CURRENCYUNIT = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_CURRENCYUNIT),
+        SDLK_CURRENCYSUBUNIT =
+            SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_CURRENCYSUBUNIT),
+        SDLK_KP_LEFTPAREN = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_KP_LEFTPAREN),
+        SDLK_KP_RIGHTPAREN = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_KP_RIGHTPAREN),
+        SDLK_KP_LEFTBRACE = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_KP_LEFTBRACE),
+        SDLK_KP_RIGHTBRACE = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_KP_RIGHTBRACE),
+        SDLK_KP_TAB = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_KP_TAB),
+        SDLK_KP_BACKSPACE = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_KP_BACKSPACE),
+        SDLK_KP_A = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_KP_A),
+        SDLK_KP_B = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_KP_B),
+        SDLK_KP_C = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_KP_C),
+        SDLK_KP_D = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_KP_D),
+        SDLK_KP_E = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_KP_E),
+        SDLK_KP_F = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_KP_F),
+        SDLK_KP_XOR = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_KP_XOR),
+        SDLK_KP_POWER = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_KP_POWER),
+        SDLK_KP_PERCENT = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_KP_PERCENT),
+        SDLK_KP_LESS = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_KP_LESS),
+        SDLK_KP_GREATER = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_KP_GREATER),
+        SDLK_KP_AMPERSAND = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_KP_AMPERSAND),
+        SDLK_KP_DBLAMPERSAND =
+            SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_KP_DBLAMPERSAND),
+        SDLK_KP_VERTICALBAR =
+            SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_KP_VERTICALBAR),
+        SDLK_KP_DBLVERTICALBAR =
+            SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_KP_DBLVERTICALBAR),
+        SDLK_KP_COLON = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_KP_COLON),
+        SDLK_KP_HASH = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_KP_HASH),
+        SDLK_KP_SPACE = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_KP_SPACE),
+        SDLK_KP_AT = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_KP_AT),
+        SDLK_KP_EXCLAM = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_KP_EXCLAM),
+        SDLK_KP_MEMSTORE = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_KP_MEMSTORE),
+        SDLK_KP_MEMRECALL = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_KP_MEMRECALL),
+        SDLK_KP_MEMCLEAR = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_KP_MEMCLEAR),
+        SDLK_KP_MEMADD = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_KP_MEMADD),
+        SDLK_KP_MEMSUBTRACT =
+            SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_KP_MEMSUBTRACT),
+        SDLK_KP_MEMMULTIPLY =
+            SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_KP_MEMMULTIPLY),
+        SDLK_KP_MEMDIVIDE = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_KP_MEMDIVIDE),
+        SDLK_KP_PLUSMINUS = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_KP_PLUSMINUS),
+        SDLK_KP_CLEAR = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_KP_CLEAR),
+        SDLK_KP_CLEARENTRY = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_KP_CLEARENTRY),
+        SDLK_KP_BINARY = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_KP_BINARY),
+        SDLK_KP_OCTAL = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_KP_OCTAL),
+        SDLK_KP_DECIMAL = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_KP_DECIMAL),
+        SDLK_KP_HEXADECIMAL =
+            SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_KP_HEXADECIMAL),
+
+        SDLK_LCTRL = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_LCTRL),
+        SDLK_LSHIFT = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_LSHIFT),
+        SDLK_LALT = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_LALT),
+        SDLK_LGUI = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_LGUI),
+        SDLK_RCTRL = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_RCTRL),
+        SDLK_RSHIFT = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_RSHIFT),
+        SDLK_RALT = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_RALT),
+        SDLK_RGUI = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_RGUI),
+
+        SDLK_MODE = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_MODE),
+
+        SDLK_AUDIONEXT = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_AUDIONEXT),
+        SDLK_AUDIOPREV = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_AUDIOPREV),
+        SDLK_AUDIOSTOP = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_AUDIOSTOP),
+        SDLK_AUDIOPLAY = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_AUDIOPLAY),
+        SDLK_AUDIOMUTE = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_AUDIOMUTE),
+        SDLK_MEDIASELECT = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_MEDIASELECT),
+        SDLK_WWW = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_WWW),
+        SDLK_MAIL = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_MAIL),
+        SDLK_CALCULATOR = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_CALCULATOR),
+        SDLK_COMPUTER = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_COMPUTER),
+        SDLK_AC_SEARCH = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_AC_SEARCH),
+        SDLK_AC_HOME = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_AC_HOME),
+        SDLK_AC_BACK = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_AC_BACK),
+        SDLK_AC_FORWARD = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_AC_FORWARD),
+        SDLK_AC_STOP = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_AC_STOP),
+        SDLK_AC_REFRESH = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_AC_REFRESH),
+        SDLK_AC_BOOKMARKS = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_AC_BOOKMARKS),
+
+        SDLK_BRIGHTNESSDOWN =
+            SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_BRIGHTNESSDOWN),
+        SDLK_BRIGHTNESSUP = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_BRIGHTNESSUP),
+        SDLK_DISPLAYSWITCH = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_DISPLAYSWITCH),
+        SDLK_KBDILLUMTOGGLE =
+            SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_KBDILLUMTOGGLE),
+        SDLK_KBDILLUMDOWN = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_KBDILLUMDOWN),
+        SDLK_KBDILLUMUP = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_KBDILLUMUP),
+        SDLK_EJECT = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_EJECT),
+        SDLK_SLEEP = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_SLEEP)
+    };
+
+    typedef enum
+    {
+        KMOD_NONE = 0x0000,
+        KMOD_LSHIFT = 0x0001,
+        KMOD_RSHIFT = 0x0002,
+        KMOD_LCTRL = 0x0040,
+        KMOD_RCTRL = 0x0080,
+        KMOD_LALT = 0x0100,
+        KMOD_RALT = 0x0200,
+        KMOD_LGUI = 0x0400,
+        KMOD_RGUI = 0x0800,
+        KMOD_NUM = 0x1000,
+        KMOD_CAPS = 0x2000,
+        KMOD_MODE = 0x4000,
+        KMOD_RESERVED = 0x8000
+    } SDL_Keymod;
+
+    typedef struct SDL_Keysym
+    {
+        SDL_Scancode scancode;      /**< SDL physical key code - see ::SDL_Scancode for details */
+        SDL_Keycode sym;            /**< SDL virtual key code - see ::SDL_Keycode for details */
+        Ogre::uint16 mod;                 /**< current key modifiers */
+        Ogre::uint32 unused;
+    } SDL_Keysym;
+
+    /**
+     *  \brief Keyboard button event structure (event.key.*)
+     */
+    typedef struct SDL_KeyboardEvent
+    {
+        Ogre::uint32 type;        /**< ::SDL_KEYDOWN or ::SDL_KEYUP */
+        Ogre::uint32 timestamp;
+        Ogre::uint32 windowID;    /**< The window with keyboard focus, if any */
+        Ogre::uint8 state;        /**< ::SDL_PRESSED or ::SDL_RELEASED */
+        Ogre::uint8 repeat;       /**< Non-zero if this is a key repeat */
+        Ogre::uint8 padding2;
+        Ogre::uint8 padding3;
+        SDL_Keysym keysym;  /**< The key that was pressed or released */
+    } SDL_KeyboardEvent;
+
+    /**
+     *  \brief Mouse motion event structure (event.motion.*)
+     */
+    typedef struct SDL_MouseMotionEvent
+    {
+        Ogre::uint32 type;        /**< ::SDL_MOUSEMOTION */
+        Ogre::uint32 timestamp;
+        Ogre::uint32 windowID;    /**< The window with mouse focus, if any */
+        Ogre::uint32 which;       /**< The mouse instance id, or SDL_TOUCH_MOUSEID */
+        Ogre::uint32 state;       /**< The current button state */
+        Ogre::int32 x;           /**< X coordinate, relative to window */
+        Ogre::int32 y;           /**< Y coordinate, relative to window */
+        Ogre::int32 xrel;        /**< The relative motion in the X direction */
+        Ogre::int32 yrel;        /**< The relative motion in the Y direction */
+    } SDL_MouseMotionEvent;
+
+    /**
+     *  \brief Mouse button event structure (event.button.*)
+     */
+    typedef struct SDL_MouseButtonEvent
+    {
+        Ogre::uint32 type;        /**< ::SDL_MOUSEBUTTONDOWN or ::SDL_MOUSEBUTTONUP */
+        Ogre::uint32 timestamp;
+        Ogre::uint32 windowID;    /**< The window with mouse focus, if any */
+        Ogre::uint32 which;       /**< The mouse instance id, or SDL_TOUCH_MOUSEID */
+        Ogre::uint8 button;       /**< The mouse button index */
+        Ogre::uint8 state;        /**< ::SDL_PRESSED or ::SDL_RELEASED */
+        Ogre::uint8 clicks;       /**< 1 for single-click, 2 for double-click, etc. */
+        Ogre::uint8 padding1;
+        Ogre::int32 x;           /**< X coordinate, relative to window */
+        Ogre::int32 y;           /**< Y coordinate, relative to window */
+    } SDL_MouseButtonEvent;
+
+    /**
+     *  \brief Mouse wheel event structure (event.wheel.*)
+     */
+    typedef struct SDL_MouseWheelEvent
+    {
+        Ogre::uint32 type;        /**< ::SDL_MOUSEWHEEL */
+        Ogre::uint32 timestamp;
+        Ogre::uint32 windowID;    /**< The window with mouse focus, if any */
+        Ogre::uint32 which;       /**< The mouse instance id, or SDL_TOUCH_MOUSEID */
+        Ogre::int32 x;           /**< The amount scrolled horizontally, positive to the right and negative to the left */
+        Ogre::int32 y;           /**< The amount scrolled vertically, positive away from the user and negative toward the user */
+        Ogre::uint32 direction;   /**< Set to one of the SDL_MOUSEWHEEL_* defines. When FLIPPED the values in X and Y will be opposite. Multiply by -1 to change them back */
+    } SDL_MouseWheelEvent;
+
+    typedef union SDL_Event
+    {
+        Ogre::uint32 type;              /**< Event type, shared with all events */
+        SDL_KeyboardEvent key;          /**< Keyboard event data */
+        SDL_MouseMotionEvent motion;    /**< Mouse motion event data */
+        SDL_MouseButtonEvent button;    /**< Mouse button event data */
+        SDL_MouseWheelEvent wheel;      /**< Mouse wheel event data */
+    } SDL_Event;
+#else
+    #define MYGUI_USE_SDL2 1
+#endif
+
+#endif

--- a/Common/Input/SDL/SdlInputHandler.cpp
+++ b/Common/Input/SDL/SdlInputHandler.cpp
@@ -1,0 +1,221 @@
+
+//Thanks to Jordan Milne and Scrawl for allowing to use their
+//sdlinputwrapper files as base under the MIT license
+
+#include "Precompiled.h"
+#include "SdlInputHandler.h"
+#include "InputManager.h"
+
+#if MYGUI_USE_SDL2
+
+#include <SDL_syswm.h>
+
+namespace base
+{
+    SdlInputHandler::SdlInputHandler( SDL_Window *sdlWindow, input::InputManager *inputManager) :
+        mSdlWindow( sdlWindow ),
+		mInputManager( inputManager ),
+        mWantRelative( false ),
+        mWantMouseGrab( false ),
+        mWantMouseVisible( true ),
+        mIsMouseRelative( !mWantRelative ),
+        mWrapPointerManually( false ),
+        mGrabPointer( false ),
+        mMouseInWindow( true ),
+        mWindowHasFocus( true ),
+        mWarpX( 0 ),
+        mWarpY( 0 ),
+        mWarpCompensate( false )
+    {
+    }
+    //-----------------------------------------------------------------------------------
+    SdlInputHandler::~SdlInputHandler()
+    {
+    }
+    //-----------------------------------------------------------------------------------
+    void SdlInputHandler::handleWindowEvent( const SDL_Event& evt )
+    {
+        switch( evt.window.event )
+        {
+            case SDL_WINDOWEVENT_ENTER:
+                mMouseInWindow = true;
+                updateMouseSettings();
+                break;
+            case SDL_WINDOWEVENT_LEAVE:
+                mMouseInWindow = false;
+                updateMouseSettings();
+                break;
+            case SDL_WINDOWEVENT_FOCUS_GAINED:
+                mWindowHasFocus = true;
+                updateMouseSettings();
+                break;
+            case SDL_WINDOWEVENT_FOCUS_LOST:
+                mWindowHasFocus = false;
+                updateMouseSettings();
+                break;
+        }
+    }
+    //-----------------------------------------------------------------------------------
+    void SdlInputHandler::_handleSdlEvents( const SDL_Event& evt )
+    {
+        switch( evt.type )
+        {
+            case SDL_MOUSEMOTION:
+                // Ignore this if it happened due to a warp
+                if( !handleWarpMotion(evt.motion) )
+                {
+                    // If in relative mode, don't trigger events unless window has focus
+                    if( (!mWantRelative || mWindowHasFocus) && mInputManager )
+                        mInputManager->mouseMoved( evt.motion );
+
+                    // Try to keep the mouse inside the window
+                    if (mWindowHasFocus)
+                        wrapMousePointer( evt.motion );
+                }
+                break;
+            case SDL_MOUSEWHEEL:
+                {
+                    if( mInputManager )
+                        mInputManager->mouseWheelMoved( evt.wheel );
+                }
+                break;
+            case SDL_MOUSEBUTTONDOWN:
+                {
+                    if( mInputManager )
+                        mInputManager->mousePressed( evt.button );
+                }
+                break;
+            case SDL_MOUSEBUTTONUP:
+                {
+                    if( mInputManager )
+                        mInputManager->mouseReleased( evt.button );
+                }
+                break;
+            case SDL_KEYDOWN:
+                {
+                    if( !evt.key.repeat && mInputManager )
+                        mInputManager->keyPressed( 
+							SDL_GetKeyFromScancode(evt.key.keysym.scancode), NULL );
+                }
+                break;
+			case SDL_TEXTEDITING:
+				break;
+            case SDL_TEXTINPUT:
+                {
+                    if( !evt.key.repeat && mInputManager )
+                        mInputManager->keyPressed( 
+							SDL_GetKeyFromScancode(evt.key.keysym.scancode), &evt.text );
+                }
+                break;
+            case SDL_KEYUP:
+                {
+                    if( !evt.key.repeat && mInputManager )
+                        mInputManager->keyReleased( evt.key );
+                }
+                break;
+            case SDL_JOYAXISMOTION:
+            case SDL_JOYBUTTONDOWN:
+            case SDL_JOYBUTTONUP:
+            case SDL_JOYDEVICEADDED:
+            case SDL_JOYDEVICEREMOVED:
+				std::cerr << "Warning. Caught unexpected SDL event. Ignored." <<  std::endl;
+                break;
+            case SDL_WINDOWEVENT:
+                handleWindowEvent(evt);
+                break;
+            /*default:
+                std::cerr << "Unhandled SDL event of type " << evt.type << std::endl;
+                break;*/
+        }
+    }
+    //-----------------------------------------------------------------------------------
+    void SdlInputHandler::setGrabMousePointer( bool grab )
+    {
+        mWantMouseGrab = grab;
+        updateMouseSettings();
+    }
+    //-----------------------------------------------------------------------------------
+    void SdlInputHandler::setMouseRelative( bool relative )
+    {
+        mWantRelative = relative;
+        updateMouseSettings();
+    }
+    //-----------------------------------------------------------------------------------
+    void SdlInputHandler::setMouseVisible( bool visible )
+    {
+        mWantMouseVisible = visible;
+        updateMouseSettings();
+    }
+    //-----------------------------------------------------------------------------------
+    void SdlInputHandler::updateMouseSettings(void)
+    {
+        mGrabPointer = mWantMouseGrab && mMouseInWindow && mWindowHasFocus;
+        SDL_SetWindowGrab( mSdlWindow, mGrabPointer ? SDL_TRUE : SDL_FALSE );
+
+        SDL_ShowCursor( mWantMouseVisible || !mWindowHasFocus );
+
+        bool relative = mWantRelative && mMouseInWindow && mWindowHasFocus;
+        if( mIsMouseRelative == relative )
+            return;
+
+        mIsMouseRelative = relative;
+
+        mWrapPointerManually = false;
+
+        //Input driver doesn't support relative positioning. Do it manually.
+        int success = SDL_SetRelativeMouseMode( relative ? SDL_TRUE : SDL_FALSE );
+        if( !relative || (relative && success != 0) )
+            mWrapPointerManually = true;
+
+        //Remove all pending mouse events that were queued with the old settings.
+        SDL_PumpEvents();
+        SDL_FlushEvent( SDL_MOUSEMOTION );
+    }
+    //-----------------------------------------------------------------------------------
+    void SdlInputHandler::warpMouse( int x, int y )
+    {
+        SDL_WarpMouseInWindow( mSdlWindow, x, y );
+        mWarpCompensate = true;
+        mWarpX = x;
+        mWarpY = y;
+    }
+    //-----------------------------------------------------------------------------------
+    void SdlInputHandler::wrapMousePointer( const SDL_MouseMotionEvent& evt )
+    {
+        //Don't wrap if we don't want relative movements, support
+        //relative movements natively, or aren't grabbing anyways
+        if( mIsMouseRelative || !mWrapPointerManually || !mGrabPointer )
+            return;
+
+        int width = 0;
+        int height = 0;
+
+        SDL_GetWindowSize( mSdlWindow, &width, &height );
+
+        const int FUDGE_FACTOR_X = width;
+        const int FUDGE_FACTOR_Y = height;
+
+        //Warp the mouse if it's about to go outside the window
+        if( evt.x - FUDGE_FACTOR_X < 0  || evt.x + FUDGE_FACTOR_X > width ||
+            evt.y - FUDGE_FACTOR_Y < 0  || evt.y + FUDGE_FACTOR_Y > height )
+        {
+            warpMouse( width / 2, height / 2 );
+        }
+    }
+    //-----------------------------------------------------------------------------------
+    bool SdlInputHandler::handleWarpMotion( const SDL_MouseMotionEvent& evt )
+    {
+        if( !mWarpCompensate )
+            return false;
+
+        //This was a warp event, signal the caller to eat it.
+        if( evt.x == mWarpX && evt.y == mWarpY )
+        {
+            mWarpCompensate = false;
+            return true;
+        }
+
+        return false;
+    }
+}
+#endif

--- a/Common/Input/SDL/SdlInputHandler.h
+++ b/Common/Input/SDL/SdlInputHandler.h
@@ -1,0 +1,86 @@
+
+//Thanks to Jordan Milne and Scrawl for allowing to use their
+//sdlinputwrapper files as base under the MIT license
+
+#ifndef _Base_SdlInputHandler_H_
+#define _Base_SdlInputHandler_H_
+
+#ifdef MYGUI_SAMPLES_INPUT_SDL2
+#include "SdlEmulationLayer.h"
+#endif
+
+#include <SDL.h>
+
+namespace input
+{
+	class InputManager;
+}
+
+namespace base
+{
+
+    class SdlInputHandler
+    {
+        SDL_Window  *mSdlWindow;
+        input::InputManager *mInputManager;
+
+        // User settings
+        // User setting. From the SDL docs: While the mouse is in relative mode, the
+        // cursor is hidden, and the driver will try to report continuous motion in
+        // the current window. Only relative motion events will be delivered, the
+        // mouse position will not change.
+        bool        mWantRelative;
+        // Locks the pointer to remain inside the window.
+        bool        mWantMouseGrab;
+        // Whether to show the mouse.
+        bool        mWantMouseVisible;
+
+        // Describes internal state.
+        bool        mIsMouseRelative;
+        // Used when driver doesn't support relative mode.
+        bool        mWrapPointerManually;
+        bool        mGrabPointer;
+        bool        mMouseInWindow;
+        bool        mWindowHasFocus;
+
+        Uint16      mWarpX;
+        Uint16      mWarpY;
+        bool        mWarpCompensate;
+
+        void updateMouseSettings(void);
+
+        void handleWindowEvent( const SDL_Event& evt );
+
+        // Moves the mouse to the specified point within the viewport
+        void warpMouse( int x, int y);
+
+        // Prevents the mouse cursor from leaving the window.
+        void wrapMousePointer( const SDL_MouseMotionEvent& evt );
+
+        // Internal method for ignoring relative
+        // motions as a side effect of warpMouse()
+        bool handleWarpMotion( const SDL_MouseMotionEvent& evt );
+
+    public:
+		SdlInputHandler(SDL_Window *sdlWindow, input::InputManager *inputManager);
+        virtual ~SdlInputHandler();
+
+        void _handleSdlEvents( const SDL_Event& evt );
+
+        // Locks the pointer to the window
+        void setGrabMousePointer( bool grab );
+
+        // Set the mouse to relative positioning mode (when not supported
+        // by hardware, we emulate the behavior).
+        // From the SDL docs: While the mouse is in relative mode, the
+        // cursor is hidden, and the driver will try to report continuous
+        // motion in the current window. Only relative motion events will
+        // be delivered, the mouse position will not change.
+        void setMouseRelative( bool relative );
+
+        // Shows or hides the mouse cursor.
+        void setMouseVisible( bool visible );
+    };
+}
+
+#endif


### PR DESCRIPTION
 If you set "MYGUI_SAMPLES_INPUT" to "4" in your CMake configuration, input handling and main window are controlled under SDL2.

You have to set "SDL2_INCLUDE_DIR" and "SDL2_LIBRARY" in your CMake configuration.
 In the "Ogre 2.0+ Forum" some people have posted some codes for SDL2 + MyGUI. Those worked well in my Ogre2.1 application. So i composed those codes into this commit.

* Building and testing environment:
	Win10 64bit VS2015
	Debug or Release buiding.

* MyGUI environment:
	CMake parameter "MYGUI_RENDERSYSTEM" : 8
	CMake parameter "MYGUI_SAMPLES_INPUT" : 4

        Examples of custom parameters:
        "SDL2_INCLUDE_DIR" : C:/path/to/OgreDep/Dependencies/include/SDL2
        "SDL2_LIBRARY" : winmm;imm32;version;msimg32;C:/path/to/OgreDep/Dependencies/lib/SDL2.lib

* Ogre environment:
	Revision: 9774
	Changeset: 159e98b4e6acf890441781671da82f601f55bd80 [159e98b4e6ac]

	"OpenGL 3+ Rendering Subsystem" or
	"Direct3D11 Rendering Subsystem"

* SDL2 environment
	2.0.5

* Test passed projects:
	Demo_Colour
	Demo_Console
	Demo_Controllers
	Demo_Gui
	Demo_ItemBox
	Demo_PluginStrangeButton
	Demo_RenderBox (but there are 2 empty panel)
	Demo_Themes (checkbox can't be checked?)
	TestApp

* Test not passed projects:
	Demo_PanelView (reason : i can't build this)
	SkinEditor (reason : i can't build this)
	LayoutEditor (reason : i can't build this)
	FontEditor (reason : i can't build this)
	ImageEditor (reason : i can't build this)
	Demo_Pointer (reason :
		Add below line to BaseManager.cpp(295), pointer is
		visible. But the pointer icon isn't changed well.
>		MyGUI::Singleton<MyGUI::PointerManager>::getInstancePtr()->setVisible(true);

* Note:
	My goal :
	The workflow of SDL2(https://wiki.libsdl.org/Tutorials/TextInput).
	This patch haven't supported all steps of the workflow yet.