### PR TITLE
added a function to specify skin for individual column of MultiListBox

### DIFF
--- a/MyGUIEngine/include/MyGUI_ListBox.h
+++ b/MyGUIEngine/include/MyGUI_ListBox.h
@@ -302,6 +302,8 @@ namespace MyGUI
 		size_t getIndexByWidget(Widget* _widget);
 
 	private:
+		friend class MultiListBox; // experimental
+
 		std::string mSkinLine;
 		ScrollBar* mWidgetScroll;
 

--- a/MyGUIEngine/include/MyGUI_MultiListBox.h
+++ b/MyGUIEngine/include/MyGUI_MultiListBox.h
@@ -139,6 +139,13 @@ namespace MyGUI
 		*/
 		void setColumnResizingPolicyAt(size_t _index, ResizingPolicy _value);
 
+		/** Set column item skin (experimental)
+		@param _column Index of column
+		@param _skin New skin (default: "ListBoxItem")
+		@note Should be called before adding item
+		*/
+		void setColumnSkinLineAt(size_t _column, const std::string& _skin);
+
 		//------------------------------------------------------------------------------//
 		// манипуляции данными
 

--- a/MyGUIEngine/src/MyGUI_MultiListBox.cpp
+++ b/MyGUIEngine/src/MyGUI_MultiListBox.cpp
@@ -88,6 +88,12 @@ namespace MyGUI
 		updateColumns();
 	}
 
+	void MultiListBox::setColumnSkinLineAt(size_t _column, const std::string& _skin)
+	{
+		MYGUI_ASSERT_RANGE(_column, mVectorColumnInfo.size(), "MultiListBox::setColumnSkinLineAt");
+		mVectorColumnInfo[_column].list->mSkinLine = _skin;
+	}
+
 	void MultiListBox::setColumnWidthAt(size_t _column, int _width)
 	{
 		MYGUI_ASSERT_RANGE(_column, mVectorColumnInfo.size(), "MultiListBox::setColumnWidthAt");


### PR DESCRIPTION
Hi,

I added a function to specify skin for individual column of MultiListBox. The reason to do this is because I made a skin whose list box selection has border:

![before](https://user-images.githubusercontent.com/3397779/31241126-84f62546-aa35-11e7-8b76-dee153af0ad0.PNG)

By specifying different skin to different column (for example the first and the last has different skin from others) the border looks nicer:

![after](https://user-images.githubusercontent.com/3397779/31241147-949286a2-aa35-11e7-97a0-7fb82fa2f821.PNG)

At the same time I also made the last column aligned right by specifying alignment in the skin definition.

I don't know if this patch fits into the style of the MyGUI project, since the code is rather ad-hoc.

Also, a further idea is that adding check boxes to MultiList using the similar technique.