### PR TITLE
added another slightly advanced compare function for MultiListBox

### DIFF
--- a/MyGUIEngine/include/MyGUI_MultiListBox.h
+++ b/MyGUIEngine/include/MyGUI_MultiListBox.h
@@ -24,6 +24,7 @@ namespace MyGUI
 	typedef delegates::CMultiDelegate5<Widget*, size_t, const UString&, const UString&, bool&> EventHandle_WidgetIntUTFStringUTFStringBool;
 
 	typedef delegates::CDelegate5<MultiListBox*, size_t, const UString&, const UString&, bool&> EventHandle_MultiListPtrSizeTCUTFStringRefCUTFStringRefBoolRef;
+	typedef delegates::CDelegate5<MultiListBox*, size_t, size_t, size_t, bool&> EventHandle_MultiListPtrSizeTSizeTSizeTBoolRef;
 	typedef delegates::CMultiDelegate2<MultiListBox*, size_t> EventHandle_MultiListPtrSizeT;
 
 	/** \brief @wpage{MultiListBox}
@@ -286,6 +287,16 @@ namespace MyGUI
 			@param _less Comparsion result (write your value here)
 		*/
 		EventHandle_MultiListPtrSizeTCUTFStringRefCUTFStringRefBoolRef requestOperatorLess;
+
+		/** Event : Less than operator for sort multilist by columns. This has higher priority than \ref requestOperatorLess.\n
+		signature : void method(MyGUI::MultiListBox* _sender, size_t _column, size_t _index1, size_t _index2, bool& _less)\n
+		@param _sender widget that called this event
+		@param _column Index of column
+		@param _index1 Index of row for compare
+		@param _index2 Index of row for compare
+		@param _less Comparsion result (write your value here)
+		*/
+		EventHandle_MultiListPtrSizeTSizeTSizeTBoolRef requestOperatorLess2;
 
 		/*internal:*/
 		// IItemContainer impl

--- a/MyGUIEngine/src/MyGUI_MultiListBox.cpp
+++ b/MyGUIEngine/src/MyGUI_MultiListBox.cpp
@@ -375,7 +375,9 @@ namespace MyGUI
 		bool result = false;
 		if (mSortUp)
 			std::swap(_left, _right);
-		if (requestOperatorLess.empty())
+		if (!requestOperatorLess2.empty())
+			requestOperatorLess2(this, mSortColumnIndex, BiIndexBase::convertToFace(_left), BiIndexBase::convertToFace(_right), result);
+		else if (requestOperatorLess.empty())
 			result = _list->getItemNameAt(_left) < _list->getItemNameAt(_right);
 		else
 			requestOperatorLess(this, mSortColumnIndex, _list->getItemNameAt(_left), _list->getItemNameAt(_right), result);


### PR DESCRIPTION
Hi,

I has added a slightly advanced compare function to MultiListBox. The new compare function receives the (unsorted) index of two rows, hence can do compare utilizing external data (for example user data stored outside).

An application is sort file by name/extension, etc. (Namely, the folders should be occurred first, then files, also, the files which have same extension should be further sorted by name.)

Before:

![before2](https://user-images.githubusercontent.com/3397779/31241701-553c69e4-aa37-11e7-88d3-7d011498fdce.PNG)

After:

![after2](https://user-images.githubusercontent.com/3397779/31241716-5b803d3a-aa37-11e7-9af5-9ae969cc6b1d.PNG)

I don't know if this patch fits into the style of the MyGUI project, since the code is rather ad-hoc.