### PR TITLE
Added eventNotifyItem to MultiListBox

### DIFF
--- a/MyGUIEngine/include/MyGUI_MultiListBox.h
+++ b/MyGUIEngine/include/MyGUI_MultiListBox.h
@@ -26,6 +26,7 @@ namespace MyGUI
 	typedef delegates::CDelegate5<MultiListBox*, size_t, const UString&, const UString&, bool&> EventHandle_MultiListPtrSizeTCUTFStringRefCUTFStringRefBoolRef;
 	typedef delegates::CDelegate5<MultiListBox*, size_t, size_t, size_t, bool&> EventHandle_MultiListPtrSizeTSizeTSizeTBoolRef;
 	typedef delegates::CMultiDelegate2<MultiListBox*, size_t> EventHandle_MultiListPtrSizeT;
+	typedef delegates::CMultiDelegate2<MultiListBox*, const IBNotifyItemData&> EventHandle_MultiListPtrCIBNotifyCellDataRef;
 
 	/** \brief @wpage{MultiListBox}
 		MultiListBox widget description should be here.
@@ -285,6 +286,13 @@ namespace MyGUI
 		*/
 		EventPair<EventHandle_MultiListPtrSizeTCUTFStringRefCUTFStringRefBoolRef, EventHandle_MultiListPtrSizeTSizeTSizeTBoolRef> requestOperatorLess;
 
+		/** Event : Notify about event in item widget.\n
+		signature : void method(MyGUI::MultiList* _sender, const MyGUI::IBNotifyItemData& _info)
+		@param _sender widget that called this event
+		@param _info info about item notify
+		*/
+		EventHandle_MultiListPtrCIBNotifyCellDataRef eventNotifyItem;
+
 		/*internal:*/
 		// IItemContainer impl
 		size_t _getItemCount() override;
@@ -307,6 +315,7 @@ namespace MyGUI
 		void notifyListChangeScrollPosition(ListBox* _sender, size_t _position);
 		void notifyButtonClick(Widget* _sender);
 		void notifyListSelectAccept(ListBox* _sender, size_t _position);
+		void notifyListNotifyItem(ListBox* _sender, const MyGUI::IBNotifyItemData& _info);
 
 		void updateColumns();
 		void redrawButtons();

--- a/MyGUIEngine/src/MyGUI_MultiListBox.cpp
+++ b/MyGUIEngine/src/MyGUI_MultiListBox.cpp
@@ -252,6 +252,13 @@ namespace MyGUI
 		eventListSelectAccept(this, BiIndexBase::convertToFace(_position));
 	}
 
+	void MultiListBox::notifyListNotifyItem(ListBox * _sender, const MyGUI::IBNotifyItemData & _info)
+	{
+		IBNotifyItemData infoConvertedIndex(_info);
+		infoConvertedIndex.index = BiIndexBase::convertToFace(_info.index);
+		eventNotifyItem(this, infoConvertedIndex);
+	}
+
 	void MultiListBox::notifyListChangeFocus(ListBox* _sender, size_t _position)
 	{
 		for (VectorColumnInfo::iterator iter = mVectorColumnInfo.begin(); iter != mVectorColumnInfo.end(); ++iter)
@@ -698,6 +705,7 @@ namespace MyGUI
 		column.list->eventListMouseItemFocus += newDelegate(this, &MultiListBox::notifyListChangeFocus);
 		column.list->eventListChangeScroll += newDelegate(this, &MultiListBox::notifyListChangeScrollPosition);
 		column.list->eventListSelectAccept += newDelegate(this, &MultiListBox::notifyListSelectAccept);
+		column.list->eventNotifyItem += newDelegate(this, &MultiListBox::notifyListNotifyItem);
 
 		if (mHeaderPlace != nullptr)
 			column.button = mHeaderPlace->createWidget<Button>(mSkinButton, IntCoord(), Align::Default);


### PR DESCRIPTION
Added eventNotifyItem to MultListBox, similar to ListBox and ItemBox. This passes on mouse and keyboard events that occur for the list items.