### PR TITLE
Fix compilation errors in Windows

### DIFF
--- a/CMake/Utils/PrecompiledHeader.cmake
+++ b/CMake/Utils/PrecompiledHeader.cmake
@@ -16,7 +16,7 @@
 macro(use_precompiled_header TARGET HEADER_FILE SRC_FILE)
   get_filename_component(HEADER ${HEADER_FILE} NAME)
 
-  if (MSVC)
+  if (MSVC AND NOT ${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
     add_definitions(/Yu"${HEADER}")
     set_source_files_properties(${SRC_FILE}
       PROPERTIES COMPILE_FLAGS /Yc"${HEADER}"

--- a/MyGUIEngine/CMakeLists.txt
+++ b/MyGUIEngine/CMakeLists.txt
@@ -45,15 +45,15 @@ if (UNIX)
 endif()
 
 if (MYGUI_USE_FREETYPE)
-	target_link_libraries(${PROJECTNAME} ${FREETYPE_LIBRARIES})
-	if (ZLIB_FOUND) # hacky way to check if freetype was built with zlib
-		target_link_libraries(${PROJECTNAME} ${ZLIB_LIBRARIES})
-	endif()
-
 	if (MYGUI_MSDF_FONTS)
 		add_subdirectory(src/msdfgen)
 		target_link_libraries(${PROJECTNAME} msdfgen)
 	endif ()
+
+	target_link_libraries(${PROJECTNAME} ${FREETYPE_LIBRARIES})
+	if (ZLIB_FOUND) # hacky way to check if freetype was built with zlib
+		target_link_libraries(${PROJECTNAME} ${ZLIB_LIBRARIES})
+	endif()
 endif()
 
 # platform specific dependencies

--- a/MyGUIEngine/include/MyGUI_FontData.h
+++ b/MyGUIEngine/include/MyGUI_FontData.h
@@ -16,7 +16,7 @@ namespace MyGUI
 	namespace FontCodeType
 	{
 
-		enum Enum
+		enum Enum: std::uint_least64_t
 		{
 			Tab = 0x0009,
 			LF = 0x000A,


### PR DESCRIPTION
Here are the 3 fixes:

1. clang-cl: disable precompiled header
2. clang-cl: force the enum size to be at least 64 bit to avoid overflow
3. mingw: reorder the linking of msdfgen and freetype since msdfgen depends on freetype