### PR TITLE
Fix warning when compiling with C++17

### DIFF
--- a/MyGUIEngine/include/MyGUI_LogStream.h
+++ b/MyGUIEngine/include/MyGUI_LogStream.h
@@ -26,7 +26,7 @@ namespace MyGUI
 		}
 
 		template <typename T>
-		LogStream& operator << (T _value)
+		LogStream& operator << (const T& _value)
 		{
 			mStream << _value;
 			return *this;


### PR DESCRIPTION
OpenMW recently upgraded to C++17 which made VS emit a new warning:

> warning C4866: compiler may not enforce left-to-right evaluation order

https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c4866?view=vs-2019

This PR does as the article suggests and takes the value by const reference. Which worked to eliminate the warning.