### PR TITLE
fix EditBox Scroll Position

### DIFF
--- a/MyGUIEngine/src/MyGUI_EditBox.cpp
+++ b/MyGUIEngine/src/MyGUI_EditBox.cpp
@@ -181,25 +181,25 @@ namespace MyGUI
 		mCursorTimer = 0;
 		mActionMouseTimer = 0;
 
-		size_t Old = mCursorPosition;
+		size_t old = mCursorPosition;
 		IntPoint point(_left, _top);
 		mCursorPosition = mClientText->getCursorPosition(point);
-		if (Old == mCursorPosition)
-			return;
 
-		mClientText->setCursorPosition(mCursorPosition);
+		if (old != mCursorPosition)
+		{
+			mClientText->setCursorPosition(mCursorPosition);
 
-		// если не было выделения
-		if (mStartSelect == ITEM_NONE)
-			mStartSelect = Old;
+			if (mStartSelect == ITEM_NONE)
+				mStartSelect = old;
 
-		// меняем выделение
-		mEndSelect = (size_t)mCursorPosition;
-		if (mStartSelect > mEndSelect)
-			mClientText->setTextSelection(mEndSelect, mStartSelect);
-		else
-			mClientText->setTextSelection(mStartSelect, mEndSelect);
+			mEndSelect = (size_t)mCursorPosition;
+			if (mStartSelect > mEndSelect)
+				mClientText->setTextSelection(mEndSelect, mStartSelect);
+			else
+				mClientText->setTextSelection(mStartSelect, mEndSelect);
 
+			updateViewWithCursor();
+		}
 	}
 
 	void EditBox::notifyMouseButtonDoubleClick(Widget* _sender)


### PR DESCRIPTION
notifyMouseDrag event of EditBox is not update view.

before：

![1](https://user-images.githubusercontent.com/12685126/97112848-9bca0600-1721-11eb-8b8d-98b94626c5cf.gif)

after：

![2](https://user-images.githubusercontent.com/12685126/97112851-9e2c6000-1721-11eb-9af2-57d2ebbfd391.gif)
