### PR TITLE
Fixes with Demos and Unit Tests

### DIFF
--- a/Common/Base/Ogre/BaseManager.cpp
+++ b/Common/Base/Ogre/BaseManager.cpp
@@ -62,8 +62,6 @@ namespace base
 		ASSERT(wmInfo.subsystem == SDL_SYSWM_COCOA);
 		params["externalWindowHandle"] = Ogre::StringConverter::toString(size_t(wmInfo.info.cocoa.window));
 #endif
-		params["vsync"] = "true";
-
 		mWindow = mRoot->createRenderWindow("MainRenderWindow", _width, _height, false, &params);
 
 		mSceneManager = mRoot->createSceneManager(Ogre::ST_GENERIC, "BaseSceneManager");
@@ -119,8 +117,7 @@ namespace base
 	{
 		setupResources();
 		mPlatform = new MyGUI::OgrePlatform();
-		mPlatform->initialise(mWindow, mSceneManager, Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
-		Ogre::ResourceGroupManager::getSingleton().initialiseAllResourceGroups();
+		mPlatform->initialise(mWindow, mSceneManager, Ogre::ResourceGroupManager::AUTODETECT_RESOURCE_GROUP_NAME);
 	}
 
 	void BaseManager::destroyGuiPlatform()
@@ -180,6 +177,8 @@ namespace base
 	void BaseManager::setupResources()
 	{
 		SdlBaseManager::setupResources();
+
+		Ogre::ResourceGroupManager::getSingleton().initialiseAllResourceGroups();
 	}
 
 	MyGUI::MapString BaseManager::getStatistic()

--- a/Common/Base/Ogre/BaseManager.cpp
+++ b/Common/Base/Ogre/BaseManager.cpp
@@ -62,6 +62,8 @@ namespace base
 		ASSERT(wmInfo.subsystem == SDL_SYSWM_COCOA);
 		params["externalWindowHandle"] = Ogre::StringConverter::toString(size_t(wmInfo.info.cocoa.window));
 #endif
+		params["vsync"] = "true";
+
 		mWindow = mRoot->createRenderWindow("MainRenderWindow", _width, _height, false, &params);
 
 		mSceneManager = mRoot->createSceneManager(Ogre::ST_GENERIC, "BaseSceneManager");
@@ -79,7 +81,6 @@ namespace base
 		// Set default mipmap level (NB some APIs ignore this)
 		Ogre::TextureManager::getSingleton().setDefaultNumMipmaps(5);
 
-		mSceneManager->setAmbientLight(Ogre::ColourValue::White);
 		Ogre::Light* light = mSceneManager->createLight("MainLight");
 		light->setType(Ogre::Light::LT_DIRECTIONAL);
 		Ogre::Vector3 vec(-0.3f, -0.3f, -0.3f);
@@ -118,7 +119,8 @@ namespace base
 	{
 		setupResources();
 		mPlatform = new MyGUI::OgrePlatform();
-		mPlatform->initialise(mWindow, mSceneManager, Ogre::ResourceGroupManager::AUTODETECT_RESOURCE_GROUP_NAME);
+		mPlatform->initialise(mWindow, mSceneManager, Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
+		Ogre::ResourceGroupManager::getSingleton().initialiseAllResourceGroups();
 	}
 
 	void BaseManager::destroyGuiPlatform()
@@ -151,7 +153,7 @@ namespace base
 		std::string name = _name;
 #endif
 
-		Ogre::ResourceGroupManager::getSingleton().addResourceLocation(name, "FileSystem", Ogre::ResourceGroupManager::AUTODETECT_RESOURCE_GROUP_NAME, _recursive);
+		Ogre::ResourceGroupManager::getSingleton().addResourceLocation(name, "FileSystem", Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME, _recursive);
 	}
 
 	void BaseManager::makeScreenShot()
@@ -178,8 +180,6 @@ namespace base
 	void BaseManager::setupResources()
 	{
 		SdlBaseManager::setupResources();
-
-		Ogre::ResourceGroupManager::getSingleton().initialiseAllResourceGroups();
 	}
 
 	MyGUI::MapString BaseManager::getStatistic()

--- a/UnitTests/UnitTest_GraphView/DemoKeeper.cpp
+++ b/UnitTests/UnitTest_GraphView/DemoKeeper.cpp
@@ -84,7 +84,7 @@ namespace demo
 		tools::DialogManager::getInstance().initialise();
 
 		Ogre::SceneNode* node = getSceneManager()->getRootSceneNode()->createChildSceneNode();
-		Ogre::Entity* entity = getSceneManager()->createEntity("Object", "Robot.mesh");
+		Ogre::Entity* entity = getSceneManager()->createEntity("Object", "robot.mesh");
 		node->attachObject(entity);
 		getCamera()->setPosition(400, 400, 400);
 

--- a/UnitTests/UnitTest_GraphView/DialogManager.h
+++ b/UnitTests/UnitTest_GraphView/DialogManager.h
@@ -15,6 +15,7 @@ namespace tools
 	{
 		MYGUI_SINGLETON_DECLARATION(DialogManager);
 	public:
+		DialogManager() : mSingletonHolder(this) { }
 		void initialise();
 		void shutdown();
 


### PR DESCRIPTION
@Altren 
This pull request contains the following fixes:
 - UnitTest_GraphView did not compile with MinGW 8.1.0 due to the Singleton initialization
 - UnitTest_GraphView was refrencing the robot.mesh with the wrong name
 - BaseManager.cpp was initializing the Resource Groups before the OGRE RenderManager was initialized
 - BaseManager.cpp was registering resources into the AUTODETECT_RESOURCE_GROUP_NAME wich makes no sense
 - BaseManager.cpp: params["vsync"] = "true" (this change was not a fix, if you want to change it later let me know)
