### PR TITLE
Do not include SDL2/..

### DIFF
--- a/CMake/Utils/MyGUIConfigTargets.cmake
+++ b/CMake/Utils/MyGUIConfigTargets.cmake
@@ -96,7 +96,7 @@ function(mygui_app PROJECTNAME SOLUTIONFOLDER)
 	# define the sources
 	include(${PROJECTNAME}.list)
 
-	include_directories(SYSTEM ${SDL2_INCLUDE_DIRS} ${SDL2_INCLUDE_DIRS}/..)
+	include_directories(SYSTEM ${SDL2_INCLUDE_DIRS})
 	link_directories(${SDL2_LIB_DIR})
 
 	# Set up dependencies
@@ -224,7 +224,7 @@ function(mygui_dll PROJECTNAME SOLUTIONFOLDER)
 	# define the sources
 	include(${PROJECTNAME}.list)
 
-	include_directories(SYSTEM ${SDL2_INCLUDE_DIRS} ${SDL2_INCLUDE_DIRS}/..)
+	include_directories(SYSTEM ${SDL2_INCLUDE_DIRS})
 	link_directories(${SDL2_LIB_DIR})
 
 	# Set up dependencies

--- a/Common/CMakeLists.txt
+++ b/Common/CMakeLists.txt
@@ -14,7 +14,7 @@ include_directories(
 set (HEADER_FILES "")
 set (SOURCE_FILES "")
 
-include_directories(SYSTEM ${SDL2_INCLUDE_DIRS} ${SDL2_INCLUDE_DIRS}/..)
+include_directories(SYSTEM ${SDL2_INCLUDE_DIRS})
 link_directories(${SDL2_LIB_DIR})
 
 mygui_set_platform_name(${MYGUI_RENDERSYSTEM})


### PR DESCRIPTION
Including `SDL2/..` may resolve in `-isystem /usr/include` which is a reasonable wontfix in gcc: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=70129