### PR TITLE
Fix window snapping when resizing

### DIFF
--- a/MyGUIEngine/src/MyGUI_Window.cpp
+++ b/MyGUIEngine/src/MyGUI_Window.cpp
@@ -265,7 +265,11 @@ namespace MyGUI
 		{
 			IntCoord coord(mCoord.point(), size);
 			getSnappedCoord(coord);
-			size = coord.size();
+			if (mCoord != coord)
+			{
+				Base::setCoord(coord);
+				return;
+			}
 		}
 
 		Base::setSize(size);
@@ -318,7 +322,7 @@ namespace MyGUI
 		{
 			IntCoord coord(pos, size);
 			getSnappedCoord(coord);
-			size = coord.size();
+			pos = coord.point();
 		}
 
 		IntCoord coord(pos, size);


### PR DESCRIPTION
27d9f9850933ca7e2918c96efab4e609c15e1b19 unified window snapping by introducing `getSnappedCoord`. Unfortunately `getSnappedCoord` only ever changes the `left` and `top` members of its argument while `setSize` and `setSize` only use the `width` and `height` members of the snapped coords they create.

This commit removes the redundant assignment to `size` and replaces it with a change to `point`.


Corresponding OpenMW issue: https://gitlab.com/OpenMW/openmw/-/issues/1025