### PR TITLE
Fix libdir setting in MYGUI.pc

### DIFF
--- a/CMake/Templates/MYGUI.pc.in
+++ b/CMake/Templates/MYGUI.pc.in
@@ -1,6 +1,6 @@
 prefix=@MYGUI_PREFIX_PATH@
 exec_prefix=${prefix}
-libdir=${prefix}/lib
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
 includedir=${prefix}/include
 
 Name: MyGUI


### PR DESCRIPTION
Use the value from GNUInstallDirs.

Installing in, say `/usr/lib64` can be accomplished with GNUInstalldirs if you specify `cmake -DCMAKE_INSTALL_LIBDIR=lib64`, which populates the `CMAKE_INSTALL_FULL_LIBDIR` variable with the appropriate prefix (also settable using `-DCMAKE_INSTALL_PREFIX` :-)