### PR TITLE
Install libMyGUICommon if tools or demos are installed, fixes #157

### DIFF
--- a/CMake/Utils/MyGUIConfigTargets.cmake
+++ b/CMake/Utils/MyGUIConfigTargets.cmake
@@ -173,13 +173,13 @@ function(mygui_app PROJECTNAME SOLUTIONFOLDER)
 	endif ()
 	set_target_properties(${PROJECTNAME} PROPERTIES FOLDER ${SOLUTIONFOLDER})
 
-	add_dependencies(${PROJECTNAME} MyGUIEngine Common)
+	add_dependencies(${PROJECTNAME} MyGUIEngine MyGUICommon)
 
 	mygui_config_sample(${PROJECTNAME})
 
 	# link Common, Platform and MyGUIEngine
 	target_link_libraries(${PROJECTNAME}
-		Common
+		MyGUICommon
 	)
 
 	if (NOT EMSCRIPTEN)
@@ -285,12 +285,12 @@ function(mygui_dll PROJECTNAME SOLUTIONFOLDER)
 
 	mygui_config_lib(${PROJECTNAME})
 
-	add_dependencies(${PROJECTNAME} MyGUIEngine Common)
+	add_dependencies(${PROJECTNAME} MyGUIEngine MyGUICommon)
 
 	mygui_config_sample(${PROJECTNAME})
 
 	target_link_libraries(${PROJECTNAME}
-		Common
+		MyGUICommon
 	)
 
 	if (NOT EMSCRIPTEN)

--- a/Common/CMakeLists.txt
+++ b/Common/CMakeLists.txt
@@ -3,7 +3,7 @@ function(mygui_add_base_manager_include PLATFORM_ID)
 	include_directories(../../Common/Base/${MYGUI_PLATFORM_NAME})
 endfunction(mygui_add_base_manager_include)
 
-set (PROJECTNAME Common)
+set (PROJECTNAME MyGUICommon)
 
 include_directories(
 	.
@@ -100,5 +100,9 @@ add_library(${PROJECTNAME} ${HEADER_FILES} ${SOURCE_FILES})
 mygui_set_platform_name(${MYGUI_RENDERSYSTEM})
 add_dependencies(${PROJECTNAME} MyGUI.${MYGUI_PLATFORM_NAME}Platform)
 target_link_libraries(${PROJECTNAME} MyGUI.${MYGUI_PLATFORM_NAME}Platform)
+if (MYGUI_INSTALL_TOOLS OR MYGUI_INSTALL_DEMOS)
+	set_target_properties(${PROJECTNAME} PROPERTIES VERSION ${MYGUI_VERSION} SOVERSION "${MYGUI_VERSION_MAJOR}.${MYGUI_VERSION_MINOR}.${MYGUI_VERSION_PATCH}")
+	mygui_install_target(${PROJECTNAME} "")
+endif()
 
 add_dependencies(${PROJECTNAME} MyGUIEngine)


### PR DESCRIPTION
See #157

Tools and demos require Common, as it is build as a shared library, so if those targets are installed, install Common also.

Renamed it, as installed as libCommon is a bit strange.