### PR TITLE
cmake: Use GNUInstallDirs to install includes

### DIFF
--- a/CMake/Utils/MyGUIConfigTargets.cmake
+++ b/CMake/Utils/MyGUIConfigTargets.cmake
@@ -406,7 +406,7 @@ function(mygui_plugin PROJECTNAME)
 	set_target_properties(${PROJECTNAME} PROPERTIES PREFIX "")
 
 	install(FILES ${HEADER_FILES}
-		DESTINATION include/MYGUI
+		DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/MYGUI"
 	)
 endfunction(mygui_plugin)
 

--- a/MyGUIEngine/CMakeLists.txt
+++ b/MyGUIEngine/CMakeLists.txt
@@ -62,5 +62,5 @@ mygui_config_lib(${PROJECTNAME})
 
 # install MyGUIEngine headers
 install(FILES ${HEADER_FILES}
-  DESTINATION include/MYGUI
+  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/MYGUI"
 )

--- a/Platforms/DirectX/DirectXPlatform/CMakeLists.txt
+++ b/Platforms/DirectX/DirectXPlatform/CMakeLists.txt
@@ -18,6 +18,6 @@ link_directories(${DirectX_LIBRARY_DIRS})
 
 # installation rules
 install(FILES ${HEADER_FILES}
-	DESTINATION include/MYGUI
+	DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/MYGUI"
 )
 mygui_install_target(${PROJECTNAME} "")

--- a/Platforms/DirectX11/DirectX11Platform/CMakeLists.txt
+++ b/Platforms/DirectX11/DirectX11Platform/CMakeLists.txt
@@ -18,6 +18,6 @@ link_directories(${DirectX_LIBRARY_DIRS})
 
 # installation rules
 install(FILES ${HEADER_FILES}
-	DESTINATION include/MYGUI
+	DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/MYGUI"
 )
 mygui_install_target(${PROJECTNAME} "")

--- a/Platforms/Dummy/DummyPlatform/CMakeLists.txt
+++ b/Platforms/Dummy/DummyPlatform/CMakeLists.txt
@@ -16,6 +16,6 @@ target_link_libraries(${PROJECTNAME} MyGUIEngine)
 
 # installation rules
 install(FILES ${HEADER_FILES}
-	DESTINATION include/MYGUI
+	DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/MYGUI"
 )
 mygui_install_target(${PROJECTNAME} "")

--- a/Platforms/Ogre/OgrePlatform/CMakeLists.txt
+++ b/Platforms/Ogre/OgrePlatform/CMakeLists.txt
@@ -17,6 +17,6 @@ link_directories(${OGRE_LIB_DIR})
 
 # installation rules
 install(FILES ${HEADER_FILES}
-	DESTINATION include/MYGUI
+	DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/MYGUI"
 )
 mygui_install_target(${PROJECTNAME} "")

--- a/Platforms/OpenGL/OpenGLPlatform/CMakeLists.txt
+++ b/Platforms/OpenGL/OpenGLPlatform/CMakeLists.txt
@@ -39,7 +39,7 @@ link_directories(${OPENGL_LIB_DIR})
 
 # installation rules
 install(FILES ${HEADER_FILES}
-	DESTINATION include/MYGUI
+	DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/MYGUI"
 )
 mygui_install_target(${PROJECTNAME} "")
 

--- a/Platforms/OpenGL3/OpenGL3Platform/CMakeLists.txt
+++ b/Platforms/OpenGL3/OpenGL3Platform/CMakeLists.txt
@@ -39,7 +39,7 @@ link_directories(${OPENGL_LIB_DIR})
 
 # installation rules
 install(FILES ${HEADER_FILES}
-	DESTINATION include/MYGUI
+	DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/MYGUI"
 )
 mygui_install_target(${PROJECTNAME} "")
 

--- a/Platforms/OpenGLES/OpenGLESPlatform/CMakeLists.txt
+++ b/Platforms/OpenGLES/OpenGLESPlatform/CMakeLists.txt
@@ -18,6 +18,6 @@ link_directories(${OPENGL_LIB_DIR})
 
 # installation rules
 install(FILES ${HEADER_FILES}
-	DESTINATION include/MYGUI
+	DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/MYGUI"
 )
 mygui_install_target(${PROJECTNAME} "")

--- a/Plugins/Plugin_BerkeliumWidget/CMakeLists.txt
+++ b/Plugins/Plugin_BerkeliumWidget/CMakeLists.txt
@@ -18,7 +18,7 @@ function(mygui_plugin_berkelium PROJECTNAME)
 	mygui_config_lib(${PROJECTNAME})
 	
 	install(FILES ${HEADER_FILES}
-		DESTINATION include/MYGUI
+		DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/MYGUI"
 	)
 endfunction(mygui_plugin_berkelium)
 


### PR DESCRIPTION
GNUInstallDirs is already used. This fixes installing includes on
multiarch/cross layouts setting the prefix to e.g. /usr/x86_64-pc-linux-gnu
or /usr/i686-pc-linux-gnu where else the includes would wrongly end up being
installed into /usr/include.