### PR TITLE
Add support for std::string_view

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,6 +170,7 @@ MARK_AS_ADVANCED(MYGUI_GENERATE_LIST_FILES_FROM_VSPROJECT)
 
 if (MSVC)
 	option(MYGUI_USE_PROJECT_FOLDERS "Use Visual Studio solution folders for projects." TRUE)
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zc:__cplusplus")
 endif ()
 
 # Used to not annoy users with high level warnings (should be TRUE for developers)

--- a/MyGUIEngine/include/MyGUI_UString.h
+++ b/MyGUIEngine/include/MyGUI_UString.h
@@ -34,6 +34,9 @@
 // these are explained later
 #include <iterator>
 #include <string>
+#if __cplusplus >= 201703L
+#include <string_view>
+#endif
 #include <stdexcept>
 
 namespace MyGUI
@@ -446,6 +449,12 @@ namespace MyGUI
 
 		explicit UString( const utf32string & str );
 
+		template <size_type num>
+		UString( const char(& str)[num] ) : UString( str, num ) {}
+
+#if __cplusplus >= 201703L
+		UString( std::string_view str ) : UString( str.data(), str.size() ) {}
+#endif
 		//! destructor
 		~UString();
 		//@}
@@ -935,6 +944,8 @@ namespace MyGUI
 		static size_type _verifyUTF8( const unsigned char* c_str );
 		//! verifies a UTF-8 stream, returning the total number of Unicode characters found
 		static size_type _verifyUTF8( const std::string& str );
+		//! verifies a UTF-8 stream, returning the total number of Unicode characters found
+		static size_type _verifyUTF8( const char* c_str, size_type num );
 		//@}
 
 	private:


### PR DESCRIPTION
This PR changes `UString` to have a `string_view` constructor when compiling with C++17. The change to CMakeLists is because of https://docs.microsoft.com/en-us/cpp/build/reference/zc-cplusplus?view=msvc-170

To make the string_view constructor worthwhile, I changed `assign` to not allocate a temporary `std::string` and to operate on `const char*` + `size_t` instead. I then also added a constructor for string literals so the `const char*` constructor doesn't get used for those, this prevents a call to `strlen`.

I also prevented out of bound accesses that would be caused by invalid UTF-8 sequences.

If MyGUI wants to switch to C++17, the `const char*`, `const std::string&`, and `const char*, size_t` constructors could straight up be replaced by a single string_view constructor.