### PR TITLE
Fix build with GCC 13

### DIFF
--- a/MyGUIEngine/include/MyGUI_Types.h
+++ b/MyGUIEngine/include/MyGUI_Types.h
@@ -9,6 +9,7 @@
 
 #include "MyGUI_Prerequest.h"
 
+#include <cstdint>
 #include <vector>
 #include <map>
 #include <string>


### PR DESCRIPTION
GCC 13 (as usual for new compiler releases) shuffles around some internal includes so some are no longer transitively included.

See https://gnu.org/software/gcc/gcc-13/porting_to.html.

Bug: https://bugs.gentoo.org/895098