### PR TITLE
Fix compilation in Visual Studio 2020

### DIFF
--- a/MyGUIEngine/include/MyGUI_FactoryManager.h
+++ b/MyGUIEngine/include/MyGUI_FactoryManager.h
@@ -20,6 +20,7 @@ namespace MyGUI
 		MYGUI_SINGLETON_DECLARATION(FactoryManager);
 	public:
 		FactoryManager();
+		FactoryManager(FactoryManager&&) = default;
 
 		void initialise();
 		void shutdown();

--- a/MyGUIEngine/include/MyGUI_ResourceManager.h
+++ b/MyGUIEngine/include/MyGUI_ResourceManager.h
@@ -25,6 +25,7 @@ namespace MyGUI
 		MYGUI_SINGLETON_DECLARATION(ResourceManager);
 	public:
 		ResourceManager();
+		ResourceManager(ResourceManager&&) = default;
 
 		void initialise();
 		void shutdown();


### PR DESCRIPTION
These types are non-copyable because they contain `Delegate`s which are move-only. MSVC doesn't appear to be able to figure this out without these constructor declarations (whereas clang works just fine.) Probably a compiler bug 🤷 