### PR TITLE
Fix compilation issues on MSVC

### DIFF
--- a/MyGUIEngine/include/MyGUI_Delegate.h
+++ b/MyGUIEngine/include/MyGUI_Delegate.h
@@ -192,6 +192,10 @@ namespace MyGUI
 			using IDelegate = DelegateFunction<Args...>;
 			using ListDelegate = typename std::list<std::unique_ptr<IDelegate>>;
 
+			// These shouldn't be necessary, but MSVC (17.6.5) requires them anyway
+			MultiDelegate() = default;
+			MultiDelegate(MultiDelegate&&) noexcept = default;
+
 			bool empty() const
 			{
 				for (const auto& delegate : mListDelegates)

--- a/Platforms/OpenGL/OpenGLPlatform/CMakeLists.txt
+++ b/Platforms/OpenGL/OpenGLPlatform/CMakeLists.txt
@@ -23,7 +23,7 @@ add_library(${PROJECTNAME} ${HEADER_FILES} ${SOURCE_FILES})
 
 add_dependencies(${PROJECTNAME} MyGUIEngine)
 
-if (APPLE)
+if (APPLE OR WIN32)
 	target_link_libraries(${PROJECTNAME} ${OPENGL_gl_LIBRARY} MyGUIEngine)
 else ()
 	# opengl instead of gl makes it compile and work in a libX11-free wayland setup

--- a/UnitTests/UnitTest_HyperTextBox/HyperTextBox.cpp
+++ b/UnitTests/UnitTest_HyperTextBox/HyperTextBox.cpp
@@ -66,8 +66,8 @@ namespace MyGUI
 
 	void HyperTextBox::parseParagraph(Widget* _parent, std::string_view _value)
 	{
-		const auto* textItem = _value.end();
-		for (const auto* item = _value.begin(); item != _value.end(); ++item)
+		auto textItem = _value.end();
+		for (auto item = _value.begin(); item != _value.end(); ++item)
 		{
 			if ((*item) == '<')
 			{
@@ -79,7 +79,7 @@ namespace MyGUI
 				}
 
 				// ищем конец тега
-				for (const auto* tagItem = item; tagItem != _value.end(); ++tagItem)
+				for (auto tagItem = item; tagItem != _value.end(); ++tagItem)
 				{
 					if ((*tagItem) == '>')
 					{


### PR DESCRIPTION
I've been a bit preoccupied these last few weeks, but now it's time to try and compile the latest changes again.

- I don't know what's up with those `MultiDelegate` constructors.
- OpenGL not linking properly by default isn't a new issue, I was just working around it before.
- Those iterators are neither `const` nor (necessarily) pointers.