### PR TITLE
Fix DLL builds by making platform library explicitly static

### DIFF
--- a/Platforms/DirectX/DirectXPlatform/CMakeLists.txt
+++ b/Platforms/DirectX/DirectXPlatform/CMakeLists.txt
@@ -9,7 +9,7 @@ include_directories(
 
 include(${PROJECTNAME}.list)
 
-add_library(${PROJECTNAME} ${HEADER_FILES} ${SOURCE_FILES})
+add_library(${PROJECTNAME} STATIC ${HEADER_FILES} ${SOURCE_FILES})
 
 add_dependencies(${PROJECTNAME} MyGUIEngine)
 

--- a/Platforms/DirectX11/DirectX11Platform/CMakeLists.txt
+++ b/Platforms/DirectX11/DirectX11Platform/CMakeLists.txt
@@ -9,7 +9,7 @@ include_directories(
 
 include(${PROJECTNAME}.list)
 
-add_library(${PROJECTNAME} ${HEADER_FILES} ${SOURCE_FILES})
+add_library(${PROJECTNAME} STATIC ${HEADER_FILES} ${SOURCE_FILES})
 
 add_dependencies(${PROJECTNAME} MyGUIEngine)
 

--- a/Platforms/Dummy/DummyPlatform/CMakeLists.txt
+++ b/Platforms/Dummy/DummyPlatform/CMakeLists.txt
@@ -8,7 +8,7 @@ include_directories(
 
 include(${PROJECTNAME}.list)
 
-add_library(${PROJECTNAME} ${HEADER_FILES} ${SOURCE_FILES})
+add_library(${PROJECTNAME} STATIC ${HEADER_FILES} ${SOURCE_FILES})
 
 add_dependencies(${PROJECTNAME} MyGUIEngine)
 

--- a/Platforms/Ogre/OgrePlatform/CMakeLists.txt
+++ b/Platforms/Ogre/OgrePlatform/CMakeLists.txt
@@ -7,7 +7,7 @@ include_directories(
 
 include(${PROJECTNAME}.list)
 
-add_library(${PROJECTNAME} ${HEADER_FILES} ${SOURCE_FILES})
+add_library(${PROJECTNAME} STATIC ${HEADER_FILES} ${SOURCE_FILES})
 
 target_include_directories(${PROJECTNAME} SYSTEM PUBLIC ${OGRE_INCLUDE_DIR})
 

--- a/Platforms/OpenGL/OpenGLPlatform/CMakeLists.txt
+++ b/Platforms/OpenGL/OpenGLPlatform/CMakeLists.txt
@@ -19,7 +19,7 @@ if (NOT MYGUI_USE_SYSTEM_GLEW)
 endif ()
 add_definitions(-DGL_GLEXT_PROTOTYPES)
 
-add_library(${PROJECTNAME} ${HEADER_FILES} ${SOURCE_FILES})
+add_library(${PROJECTNAME} STATIC ${HEADER_FILES} ${SOURCE_FILES})
 
 add_dependencies(${PROJECTNAME} MyGUIEngine)
 

--- a/Platforms/OpenGL3/OpenGL3Platform/CMakeLists.txt
+++ b/Platforms/OpenGL3/OpenGL3Platform/CMakeLists.txt
@@ -19,7 +19,7 @@ if (NOT MYGUI_USE_SYSTEM_GLEW)
 endif ()
 add_definitions(-DGL_GLEXT_PROTOTYPES)
 
-add_library(${PROJECTNAME} ${HEADER_FILES} ${SOURCE_FILES})
+add_library(${PROJECTNAME} STATIC ${HEADER_FILES} ${SOURCE_FILES})
 
 add_dependencies(${PROJECTNAME} MyGUIEngine)
 

--- a/Platforms/OpenGLES/OpenGLESPlatform/CMakeLists.txt
+++ b/Platforms/OpenGLES/OpenGLESPlatform/CMakeLists.txt
@@ -9,7 +9,7 @@ include_directories(
 
 include(${PROJECTNAME}.list)
 add_definitions(-DGL_GLEXT_PROTOTYPES)
-add_library(${PROJECTNAME} ${HEADER_FILES} ${SOURCE_FILES})
+add_library(${PROJECTNAME} STATIC ${HEADER_FILES} ${SOURCE_FILES})
 
 add_dependencies(${PROJECTNAME} MyGUIEngine)
 


### PR DESCRIPTION
We've been using this as a patch in OpenMW for a couple of months.