### PR TITLE
Explicitly mark another library as static

### DIFF
--- a/Common/CMakeLists.txt
+++ b/Common/CMakeLists.txt
@@ -99,7 +99,7 @@ SOURCE_GROUP("Base" FILES
 	Input/SDL/ResourceSDLPointer.cpp
 )
 
-add_library(${PROJECTNAME} ${HEADER_FILES} ${SOURCE_FILES})
+add_library(${PROJECTNAME} STATIC ${HEADER_FILES} ${SOURCE_FILES})
 
 mygui_set_platform_name(${MYGUI_RENDERSYSTEM})
 add_dependencies(${PROJECTNAME} MyGUI.${MYGUI_PLATFORM_NAME}Platform)


### PR DESCRIPTION
I've also figured out why this problem wasn't obvious. It only happens when someone's used the CMake-standard `BUILD_SHARED_LIBS` option, which controls the default behaviour for `add_library`. When MyGUI is built as a standalone project, this won't be set (unless someone's done it manually) so it's fine. However, when MyGUI is built as part of a larger project (e.g. package manager like vcpkg or CPM, or as a nested project with `FetchContent` or as a submodule), it's likely to have been set by something else.

It *might* be a good idea to pick the default value of `MYGUI_STATIC` to match `BUILD_SHARED_LIBS` if it's set, but I've not done that in this PR.