### PR TITLE
Fix incorrect error message on OgreRenderManager

### DIFF
--- a/Platforms/Ogre/OgrePlatform/src/MyGUI_OgreRenderManager.cpp
+++ b/Platforms/Ogre/OgrePlatform/src/MyGUI_OgreRenderManager.cpp
@@ -551,7 +551,7 @@ namespace MyGUI
 		{
 			MYGUI_ASSERT(
 				DataManager::getInstance().isDataExist(_fragmentProgramFile),
-				"Shader file '" << _vertexProgramFile << "' is missing.");
+				"Shader file '" << _fragmentProgramFile << "' is missing.");
 			shaderInfo->fragmentProgram = Ogre::HighLevelGpuProgramManager::getSingleton().createProgram(
 				_fragmentProgramFile,
 				OgreDataManager::getInstance().getGroup(),


### PR DESCRIPTION
Instead of incorrectly reporting vertex shader is missing when it isn't, correctly report fragment shader is missing