### PR TITLE
Enable CMake testing infrastructure for unit tests

### DIFF
--- a/CMake/Utils/MyGUIConfigTargets.cmake
+++ b/CMake/Utils/MyGUIConfigTargets.cmake
@@ -350,6 +350,15 @@ endfunction(mygui_tool)
 
 function(mygui_unit_test PROJECTNAME)
 	mygui_app(${PROJECTNAME} UnitTest)
+	
+	# Register the unit test with CTest when unit tests are enabled
+	# This allows running tests via 'ctest' or 'make check'
+	if (MYGUI_BUILD_UNITTESTS)
+		add_test(NAME ${PROJECTNAME} COMMAND ${PROJECTNAME})
+		# Set working directory to binary directory so tests can find resources
+		set_tests_properties(${PROJECTNAME} PROPERTIES 
+			WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+	endif()
 endfunction(mygui_unit_test)
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -319,6 +319,10 @@ endif ()
 
 # Setup tests
 if (MYGUI_BUILD_UNITTESTS OR MYGUI_BUILD_TEST_APP)
+	# Enable CMake testing infrastructure when building unit tests
+	if (MYGUI_BUILD_UNITTESTS)
+		enable_testing()
+	endif()
 	add_subdirectory(UnitTests)
 endif ()
 


### PR DESCRIPTION
- Add enable_testing() call when MYGUI_BUILD_UNITTESTS is enabled
- Register unit tests with add_test() in mygui_unit_test function
- Set working directory for tests to find resources properly
- Maintains full backwards compatibility with existing build process
- Enables running tests via 'ctest' and 'make check' commands

Fixes #273