### PR TITLE
Fix texture size cache after renderer reinitialization

### DIFF
--- a/MyGUIEngine/src/MyGUI_TextureUtility.cpp
+++ b/MyGUIEngine/src/MyGUI_TextureUtility.cpp
@@ -28,6 +28,14 @@ namespace MyGUI::texture_utility
 		RenderManager& render = RenderManager::getInstance();
 
 		ITexture* texture = render.getTexture(_texture);
+
+		if (_cache && texture != nullptr)
+		{
+			auto it = textureSizes.find(_texture);
+			if (it != textureSizes.end())
+				return it->second;
+		}
+		
 		if (texture == nullptr)
 		{
 			if (!DataManager::getInstance().isDataExist(_texture))


### PR DESCRIPTION
## Description

Fixes an issue in `texture_utility::getTextureSize()` where the static texture size cache can outlive the active `RenderManager`.

When MyGUI and the rendering backend are shut down and initialized again in the same process, `textureSizes` still contains entries from the previous initialization.

On the next initialization, `getTextureSize()` returns the cached size before checking whether the corresponding texture exists in the new `RenderManager`. As a result, the texture is never recreated or loaded.

This can cause widgets to render their text while their skin textures, images, and mouse pointer are missing after renderer reinitialization.

## Fix

Only use the cached texture size when the texture also exists in the current `RenderManager`.

If the texture no longer exists, the normal loading path is used to recreate and load it.

## Reproduction

1. Initialize MyGUI and create widgets using textured skins.
2. Shut down MyGUI and the rendering backend.
3. Reinitialize the rendering backend and MyGUI in the same process.
4. Recreate the widgets.

Before this change, cached texture dimensions can prevent skin textures from being loaded during the second initialization.

After this change, the textures are recreated correctly.
